### PR TITLE
Add risk scoring engine with multi-artifact support - closes #3

### DIFF
--- a/docs/risk_scoring.md
+++ b/docs/risk_scoring.md
@@ -1,0 +1,54 @@
+# Risk Scoring Engine — Issue #3
+
+## Formula
+
+Risk Score = (Anomaly Score × 0.6) + (Rule Score × 100 × 0.4)
+Range: 0 to 100
+
+## Priority Levels
+
+| Score    | Priority |
+| -------- | -------- |
+| 75 - 100 | CRITICAL |
+| 50 - 74  | HIGH     |
+| 25 - 49  | MEDIUM   |
+| 0 - 24   | LOW      |
+
+## Supported Artifact Types
+
+| Type       | Auto-detected by                      |
+| ---------- | ------------------------------------- |
+| network    | Flow Duration, Flow Packets/s columns |
+| system_log | EventID, LogonType columns            |
+| file       | FileName, FileExtension columns       |
+| registry   | RegistryKey, RegistryValue columns    |
+
+## Rule Weights
+
+| Rule                | Weight | Artifact Type |
+| ------------------- | ------ | ------------- |
+| High Packet Rate    | 0.8    | network       |
+| Long Flow Duration  | 0.6    | network       |
+| Large Byte Transfer | 0.7    | network       |
+| Low Packet Size     | 0.4    | network       |
+| High Failed Logins  | 0.9    | system_log    |
+| Odd Hour Login      | 0.6    | system_log    |
+| Executable in Temp  | 0.8    | file          |
+| Autorun Entry       | 0.9    | registry      |
+
+## Test Results
+
+| Priority | Count     |
+| -------- | --------- |
+| CRITICAL | 38,283    |
+| HIGH     | 764,890   |
+| MEDIUM   | 662,716   |
+| LOW      | 1,054,701 |
+
+Top risk score: 97.52 — matched rules: High Packet Rate, Large Byte Transfer
+
+## Why this formula?
+
+- Anomaly score (60%) — AI model output, objective measure
+- Rule score (40%) — domain knowledge, human expertise
+- Combined gives better results than either alone

--- a/docs/risk_scoring.md
+++ b/docs/risk_scoring.md
@@ -25,16 +25,20 @@ Range: 0 to 100
 
 ## Rule Weights
 
-| Rule                | Weight | Artifact Type |
-| ------------------- | ------ | ------------- |
-| High Packet Rate    | 0.8    | network       |
-| Long Flow Duration  | 0.6    | network       |
-| Large Byte Transfer | 0.7    | network       |
-| Low Packet Size     | 0.4    | network       |
-| High Failed Logins  | 0.9    | system_log    |
-| Odd Hour Login      | 0.6    | system_log    |
-| Executable in Temp  | 0.8    | file          |
-| Autorun Entry       | 0.9    | registry      |
+| Rule                    | Weight | Artifact Type |
+| ----------------------- | ------ | ------------- |
+| High Packet Rate        | 0.8    | network       |
+| Long Flow Duration      | 0.6    | network       |
+| Large Byte Transfer     | 0.7    | network       |
+| Low Packet Size         | 0.4    | network       |
+| High Failed Logins      | 0.9    | system_log    |
+| Odd Hour Login          | 0.6    | system_log    |
+| Privilege Escalation    | 1.0    | system_log    |
+| Executable in Temp      | 0.8    | file          |
+| Large File Created      | 0.5    | file          |
+| Hidden File Detected    | 0.7    | file          |
+| Autorun Entry           | 0.9    | registry      |
+| Suspicious Registry Key | 0.8    | registry      |
 
 ## Test Results
 

--- a/ml/risk_scorer.py
+++ b/ml/risk_scorer.py
@@ -1,7 +1,10 @@
 import numpy as np
 import pandas as pd
+import logging
 
-# Rules organized by artifact type
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
 RULES = {
     'network': {
         'high_packet_rate':    {'weight': 0.8, 'label': 'High Packet Rate'},
@@ -28,18 +31,26 @@ RULES = {
 class RiskScorer:
 
     def detect_artifact_type(self, row):
-        """Auto detect what kind of artifact this row is"""
-        keys = set(row.keys())
-        if 'Flow Duration' in keys or 'Flow Packets/s' in keys:
+        def has_value(col):
+            value = row.get(col)
+            if isinstance(value, str):
+                return value.strip() != ''
+            return pd.notna(value) if value is not None else False
+
+        explicit = row.get('artifact_type')
+        if isinstance(explicit, str) and explicit.strip().lower() in RULES:
+            return explicit.strip().lower()
+
+        if any(has_value(c) for c in ('Flow Duration','Flow Packets/s','Flow Bytes/s','Packet Length Mean')):
             return 'network'
-        elif 'EventID' in keys or 'LogonType' in keys:
+        elif any(has_value(c) for c in ('EventID','LogonType')):
             return 'system_log'
-        elif 'FileName' in keys or 'FileExtension' in keys:
+        elif any(has_value(c) for c in ('FileName','FileExtension')):
             return 'file'
-        elif 'RegistryKey' in keys or 'RegistryValue' in keys:
+        elif any(has_value(c) for c in ('RegistryKey','RegistryValue')):
             return 'registry'
         else:
-            return 'network'  # default to network for current dataset
+            return 'network'
 
     def apply_rules(self, row, artifact_type='network'):
         rule_score = 0.0
@@ -50,15 +61,12 @@ class RiskScorer:
                 if row.get('Flow Packets/s', 0) > 10000:
                     rule_score += RULES['network']['high_packet_rate']['weight']
                     matched_rules.append(RULES['network']['high_packet_rate']['label'])
-
                 if row.get('Flow Duration', 0) > 100000000:
                     rule_score += RULES['network']['long_flow_duration']['weight']
                     matched_rules.append(RULES['network']['long_flow_duration']['label'])
-
                 if row.get('Flow Bytes/s', 0) > 1000000:
                     rule_score += RULES['network']['large_byte_transfer']['weight']
                     matched_rules.append(RULES['network']['large_byte_transfer']['label'])
-
                 if row.get('Packet Length Mean', 0) < 10:
                     rule_score += RULES['network']['low_packet_size']['weight']
                     matched_rules.append(RULES['network']['low_packet_size']['label'])
@@ -67,25 +75,36 @@ class RiskScorer:
                 if row.get('FailedLogins', 0) > 5:
                     rule_score += RULES['system_log']['high_failed_logins']['weight']
                     matched_rules.append(RULES['system_log']['high_failed_logins']['label'])
-
                 if row.get('LoginHour', 12) < 6 or row.get('LoginHour', 12) > 22:
                     rule_score += RULES['system_log']['odd_login_hour']['weight']
                     matched_rules.append(RULES['system_log']['odd_login_hour']['label'])
+                if row.get('PrivilegeLevel', '') == 'SYSTEM':
+                    rule_score += RULES['system_log']['privilege_escalation']['weight']
+                    matched_rules.append(RULES['system_log']['privilege_escalation']['label'])
 
             elif artifact_type == 'file':
                 path = str(row.get('FilePath', ''))
                 if 'temp' in path.lower() and path.endswith('.exe'):
                     rule_score += RULES['file']['executable_in_temp']['weight']
                     matched_rules.append(RULES['file']['executable_in_temp']['label'])
+                if row.get('FileSizeBytes', 0) > 100000000:
+                    rule_score += RULES['file']['large_file_created']['weight']
+                    matched_rules.append(RULES['file']['large_file_created']['label'])
+                if str(row.get('FileName', '')).startswith('.'):
+                    rule_score += RULES['file']['hidden_file']['weight']
+                    matched_rules.append(RULES['file']['hidden_file']['label'])
 
             elif artifact_type == 'registry':
                 key = str(row.get('RegistryKey', ''))
                 if 'autorun' in key.lower() or 'run' in key.lower():
                     rule_score += RULES['registry']['autorun_entry']['weight']
                     matched_rules.append(RULES['registry']['autorun_entry']['label'])
+                if any(s in key.lower() for s in ('cmd','powershell','wscript','temp')):
+                    rule_score += RULES['registry']['suspicious_key']['weight']
+                    matched_rules.append(RULES['registry']['suspicious_key']['label'])
 
-        except Exception:
-            pass
+        except (KeyError, TypeError) as e:
+            logger.warning(f"Rule evaluation error at row: {e}")
 
         rule_score = min(rule_score, 1.0)
         return rule_score, matched_rules
@@ -95,11 +114,6 @@ class RiskScorer:
         return normalized * 100
 
     def compute_risk_score(self, anomaly_score, rule_score):
-        """
-        Risk Score Formula:
-        Risk = (Anomaly Score x 0.6) + (Rule Score x 100 x 0.4)
-        Range: 0 to 100
-        """
         risk = (anomaly_score * 0.6) + (rule_score * 100 * 0.4)
         return round(min(risk, 100), 2)
 
@@ -115,30 +129,44 @@ class RiskScorer:
 
     def score_dataframe(self, df_clean, anomaly_scores):
         print("[+] Scoring artifacts...")
-        results = []
+        total_records = len(df_clean)
+        columns = list(df_clean.columns)
 
-        for i, (_, row) in enumerate(df_clean.iterrows()):
-            row_dict = row.to_dict()
+        record_ids = np.arange(total_records, dtype=np.int64)
+        artifact_types = [None] * total_records
+        anomaly_score_values = np.empty(total_records, dtype=np.float64)
+        rule_score_values = np.empty(total_records, dtype=np.float64)
+        risk_score_values = np.empty(total_records, dtype=np.float64)
+        priorities = [None] * total_records
+        matched_rules_list = [None] * total_records
+
+        for i, row_values in enumerate(df_clean.itertuples(index=False, name=None)):
+            row_dict = dict(zip(columns, row_values))
             artifact_type = self.detect_artifact_type(row_dict)
             a_score = self.get_anomaly_score_normalized(anomaly_scores[i])
             r_score, rules = self.apply_rules(row_dict, artifact_type)
             risk = self.compute_risk_score(a_score, r_score)
-            priority = self.assign_priority(risk)
 
-            results.append({
-                'record_id': i,
-                'artifact_type': artifact_type,
-                'anomaly_score': round(a_score, 2),
-                'rule_score': round(r_score * 100, 2),
-                'risk_score': risk,
-                'priority': priority,
-                'matched_rules': ', '.join(rules) if rules else 'None'
-            })
+            artifact_types[i] = artifact_type
+            anomaly_score_values[i] = round(a_score, 2)
+            rule_score_values[i] = round(r_score * 100, 2)
+            risk_score_values[i] = risk
+            priorities[i] = self.assign_priority(risk)
+            matched_rules_list[i] = ', '.join(rules) if rules else 'None'
 
             if i % 100000 == 0:
-                print(f"[+] Processed {i}/{len(df_clean)} records...")
+                print(f"[+] Processed {i}/{total_records} records...")
 
-        df_results = pd.DataFrame(results)
+        df_results = pd.DataFrame({
+            'record_id': record_ids,
+            'artifact_type': artifact_types,
+            'anomaly_score': anomaly_score_values,
+            'rule_score': rule_score_values,
+            'risk_score': risk_score_values,
+            'priority': priorities,
+            'matched_rules': matched_rules_list
+        })
+
         df_results = df_results.sort_values('risk_score', ascending=False)
         print("[+] Scoring complete")
         return df_results

--- a/ml/risk_scorer.py
+++ b/ml/risk_scorer.py
@@ -1,0 +1,144 @@
+import numpy as np
+import pandas as pd
+
+# Rules organized by artifact type
+RULES = {
+    'network': {
+        'high_packet_rate':    {'weight': 0.8, 'label': 'High Packet Rate'},
+        'long_flow_duration':  {'weight': 0.6, 'label': 'Long Flow Duration'},
+        'large_byte_transfer': {'weight': 0.7, 'label': 'Large Byte Transfer'},
+        'low_packet_size':     {'weight': 0.4, 'label': 'Low Packet Size'},
+    },
+    'system_log': {
+        'high_failed_logins':  {'weight': 0.9, 'label': 'High Failed Logins'},
+        'odd_login_hour':      {'weight': 0.6, 'label': 'Odd Hour Login'},
+        'privilege_escalation':{'weight': 1.0, 'label': 'Privilege Escalation'},
+    },
+    'file': {
+        'executable_in_temp':  {'weight': 0.8, 'label': 'Executable in Temp'},
+        'large_file_created':  {'weight': 0.5, 'label': 'Large File Created'},
+        'hidden_file':         {'weight': 0.7, 'label': 'Hidden File Detected'},
+    },
+    'registry': {
+        'autorun_entry':       {'weight': 0.9, 'label': 'Autorun Entry Added'},
+        'suspicious_key':      {'weight': 0.8, 'label': 'Suspicious Registry Key'},
+    }
+}
+
+class RiskScorer:
+
+    def detect_artifact_type(self, row):
+        """Auto detect what kind of artifact this row is"""
+        keys = set(row.keys())
+        if 'Flow Duration' in keys or 'Flow Packets/s' in keys:
+            return 'network'
+        elif 'EventID' in keys or 'LogonType' in keys:
+            return 'system_log'
+        elif 'FileName' in keys or 'FileExtension' in keys:
+            return 'file'
+        elif 'RegistryKey' in keys or 'RegistryValue' in keys:
+            return 'registry'
+        else:
+            return 'network'  # default to network for current dataset
+
+    def apply_rules(self, row, artifact_type='network'):
+        rule_score = 0.0
+        matched_rules = []
+
+        try:
+            if artifact_type == 'network':
+                if row.get('Flow Packets/s', 0) > 10000:
+                    rule_score += RULES['network']['high_packet_rate']['weight']
+                    matched_rules.append(RULES['network']['high_packet_rate']['label'])
+
+                if row.get('Flow Duration', 0) > 100000000:
+                    rule_score += RULES['network']['long_flow_duration']['weight']
+                    matched_rules.append(RULES['network']['long_flow_duration']['label'])
+
+                if row.get('Flow Bytes/s', 0) > 1000000:
+                    rule_score += RULES['network']['large_byte_transfer']['weight']
+                    matched_rules.append(RULES['network']['large_byte_transfer']['label'])
+
+                if row.get('Packet Length Mean', 0) < 10:
+                    rule_score += RULES['network']['low_packet_size']['weight']
+                    matched_rules.append(RULES['network']['low_packet_size']['label'])
+
+            elif artifact_type == 'system_log':
+                if row.get('FailedLogins', 0) > 5:
+                    rule_score += RULES['system_log']['high_failed_logins']['weight']
+                    matched_rules.append(RULES['system_log']['high_failed_logins']['label'])
+
+                if row.get('LoginHour', 12) < 6 or row.get('LoginHour', 12) > 22:
+                    rule_score += RULES['system_log']['odd_login_hour']['weight']
+                    matched_rules.append(RULES['system_log']['odd_login_hour']['label'])
+
+            elif artifact_type == 'file':
+                path = str(row.get('FilePath', ''))
+                if 'temp' in path.lower() and path.endswith('.exe'):
+                    rule_score += RULES['file']['executable_in_temp']['weight']
+                    matched_rules.append(RULES['file']['executable_in_temp']['label'])
+
+            elif artifact_type == 'registry':
+                key = str(row.get('RegistryKey', ''))
+                if 'autorun' in key.lower() or 'run' in key.lower():
+                    rule_score += RULES['registry']['autorun_entry']['weight']
+                    matched_rules.append(RULES['registry']['autorun_entry']['label'])
+
+        except Exception:
+            pass
+
+        rule_score = min(rule_score, 1.0)
+        return rule_score, matched_rules
+
+    def get_anomaly_score_normalized(self, raw_score):
+        normalized = 1 / (1 + np.exp(raw_score * 10))
+        return normalized * 100
+
+    def compute_risk_score(self, anomaly_score, rule_score):
+        """
+        Risk Score Formula:
+        Risk = (Anomaly Score x 0.6) + (Rule Score x 100 x 0.4)
+        Range: 0 to 100
+        """
+        risk = (anomaly_score * 0.6) + (rule_score * 100 * 0.4)
+        return round(min(risk, 100), 2)
+
+    def assign_priority(self, risk_score):
+        if risk_score >= 75:
+            return 'CRITICAL'
+        elif risk_score >= 50:
+            return 'HIGH'
+        elif risk_score >= 25:
+            return 'MEDIUM'
+        else:
+            return 'LOW'
+
+    def score_dataframe(self, df_clean, anomaly_scores):
+        print("[+] Scoring artifacts...")
+        results = []
+
+        for i, (_, row) in enumerate(df_clean.iterrows()):
+            row_dict = row.to_dict()
+            artifact_type = self.detect_artifact_type(row_dict)
+            a_score = self.get_anomaly_score_normalized(anomaly_scores[i])
+            r_score, rules = self.apply_rules(row_dict, artifact_type)
+            risk = self.compute_risk_score(a_score, r_score)
+            priority = self.assign_priority(risk)
+
+            results.append({
+                'record_id': i,
+                'artifact_type': artifact_type,
+                'anomaly_score': round(a_score, 2),
+                'rule_score': round(r_score * 100, 2),
+                'risk_score': risk,
+                'priority': priority,
+                'matched_rules': ', '.join(rules) if rules else 'None'
+            })
+
+            if i % 100000 == 0:
+                print(f"[+] Processed {i}/{len(df_clean)} records...")
+
+        df_results = pd.DataFrame(results)
+        df_results = df_results.sort_values('risk_score', ascending=False)
+        print("[+] Scoring complete")
+        return df_results


### PR DESCRIPTION
## What this PR does
Implements the cyber triage risk scoring engine for Issue #3.
Assigns a 0-100 risk score to every artifact and prioritizes 
into CRITICAL / HIGH / MEDIUM / LOW.

## Changes
- ml/risk_scorer.py — RiskScorer class with formula and rule engine
- docs/risk_scoring.md — full documentation of formula and results

## Risk Score Formula
Risk Score = (Anomaly Score x 0.6) + (Rule Score x 100 x 0.4)

## Artifact Types Supported
- network — Flow Duration, Packet Rate, Byte Transfer rules
- system_log — Failed logins, odd hour login rules
- file — Executable in temp, hidden file rules
- registry — Autorun entry, suspicious key rules

Artifact type is auto-detected from column names.
No manual configuration needed.

## Test Results
| Priority | Count |
|---|---|
| CRITICAL | 38,283 |
| HIGH | 764,890 |
| MEDIUM | 662,716 |
| LOW | 1,054,701 |

Top risk score: 97.52/100
Top matched rules: High Packet Rate, Large Byte Transfer

## How to test
python -c "
from ml.preprocessor import ForensicPreprocessor
from ml.detector import AnomalyDetector
from ml.risk_scorer import RiskScorer
p = ForensicPreprocessor()
df_scaled, df_raw, df_clean = p.run_pipeline('data/cicids2017_cleaned.csv')
d = AnomalyDetector(contamination=0.1)
d.train(df_scaled)
predictions, scores = d.predict(df_scaled)
scorer = RiskScorer()
results = scorer.score_dataframe(df_clean, scores)
print(results[['risk_score','priority','matched_rules']].head(10))
"

Expected top result:
risk_score: 97.52 | priority: CRITICAL | matched_rules: High Packet Rate, Large Byte Transfer

## Closes
Closes #3