### PR TITLE
Add Phase 1 investigator frontend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,15 @@ models/*.joblib
 reports/*.pdf
 node_modules/
 frontend/build/
+frontend/dist/
 .DS_Store
 temp/
 *.tmp
 *.log
+
+# Local editor/agent tooling
+.claude/
+
+# Third-party design reference used while building the landing page.
+# Kept local: it describes another product's page and pins an external CDN asset.
+frontend/landingpage.md

--- a/CLAUDE_CONTEXT.md
+++ b/CLAUDE_CONTEXT.md
@@ -1,0 +1,271 @@
+# CLAUDE_CONTEXT.md
+
+Handoff notes for a fresh Claude Code session. Written 2026-08-26 after building
+the Phase 1 frontend. Read this instead of re-scanning the repo.
+
+---
+
+## 1. Project Overview
+
+Cyber Triage Tool — AI-assisted triage for early-stage digital forensic
+investigation. Academic/hackathon project for problem statement **SIH1744**
+(National Investigation Agency, Anti-Cyber Terrorism Division).
+
+An investigator uploads forensic data; the tool ranks artifacts by risk so the
+highest-value evidence is looked at first.
+
+**Stack:** Python (scikit-learn, pandas) + Flask backend · React 19 + Vite
+frontend · plain CSS. No TypeScript, no Tailwind, no MongoDB in use.
+
+**Architecture:**
+
+```
+CSV upload → ForensicPreprocessor → IsolationForest (AnomalyDetector)
+           → RiskScorer (ML score 60% + rule score 40%) → ranked artifacts + priority band
+```
+
+Flask is a thin HTTP layer; all real logic lives in `ml/`. Processing is
+per-request and stateless — nothing is persisted between calls except the
+trained model pickle.
+
+**Scope reality check:** the repo currently satisfies only requirement #4
+(AI/ML anomaly scoring) against network-flow CSVs. Disk imaging, log/registry/
+PCAP parsing, IOC matching and reporting are unbuilt. `plan.md` has the full
+breakdown.
+
+---
+
+## 2. Repository Structure
+
+| Path | Contents |
+|---|---|
+| `backend/app.py` | **Entry point.** Entire Flask API in one file. |
+| `backend/report_generator.py` | **Empty file.** PDF reporting stub. |
+| `ml/preprocessor.py` | `ForensicPreprocessor` — load, clean, extract features, scale |
+| `ml/detector.py` | `AnomalyDetector` — IsolationForest wrapper + joblib persistence |
+| `ml/risk_scorer.py` | `RiskScorer` — rule engine, risk score, priority bands |
+| `frontend/src/` | **Entry point** `main.jsx` → `App.jsx` (routes) |
+| `evaluation/evaluate.py` | **Empty file.** |
+| `docs/*.md` | Per-module design notes — read before changing `ml/` |
+| `plan.md` | Roadmap + requirement-by-requirement TODO list |
+| `data/`, `models/`, `reports/`, `temp/` | Gitignored working dirs (`.gitkeep` only) |
+
+There is no `backend/tests/`, no pytest config and no ESLint config — see §4.
+
+### Frontend layout (`frontend/src/`)
+
+| Path | Contents |
+|---|---|
+| `App.jsx` | All routes |
+| `routes/` | `LandingPage`, `LoginPage`, `DashboardPage`, `ModulePlaceholder` (+ co-located CSS) |
+| `components/dashboard/` | `AppShell`, `Sidebar`, `TopBar`, `Panel`, `StatCard`, `InvestigationRow`, `AiTriagePanel`, `ActivityFeed` |
+| `components/landing/` | `SiteHeader`, `CinematicBackground` |
+| `components/ui/` | `Icon` (hand-rolled SVG set), `SeverityBadge` |
+| `services/` | `apiClient` + `authService`, `dashboardService`, `triageService` |
+| `data/` | `mockDashboard.js` (sample fixtures), `navigation.js` (sidebar items) |
+| `styles/` | `tokens.css`, `global.css`, `page.css`, `cinematic.css` |
+| `hooks/` | `useEntranceMotion`, `useRouteMode` |
+| `config/media.js` | Background video URL — see known issues |
+
+---
+
+## 3. How It Works
+
+### Backend request flow (`/api/analyze`)
+
+1. Multipart upload in form field **`file`**, saved to `temp/` with a UUID prefix.
+2. `preprocessor.run_pipeline(path)` → returns `(df_scaled, df_raw, df_clean)`.
+3. `_ensure_detector_loaded_or_trained` — loads `models/isolation_forest.pkl` if
+   present, otherwise **trains on the uploaded data and saves it**. Guarded by a
+   module-level `DETECTOR_READY` flag, so the first upload defines the model for
+   the process lifetime.
+4. `scorer.score_dataframe(df_clean, scores)` → risk-sorted DataFrame.
+5. Returns `{summary: {total_records, critical, high, medium, low}, artifacts: [top 100]}`.
+6. If a label column is found, adds an `evaluation` block.
+7. `finally` deletes the temp file.
+
+### Scoring specifics
+
+- Anomaly score normalized via `1 / (1 + exp(raw * 10)) * 100`.
+- `risk = anomaly * 0.6 + rule_score * 100 * 0.4`, capped at 100.
+- Priority bands: **CRITICAL ≥ 75 · HIGH ≥ 50 · MEDIUM ≥ 25 · LOW below.**
+  The frontend severity colours mirror these exact thresholds — change one, change both.
+- Artifact type is sniffed from column names (`Flow Duration` → network,
+  `EventID` → system_log, `FileName` → file, `RegistryKey` → registry), defaulting
+  to `network`. Rule weights live in the `RULES` dict at the top of `risk_scorer.py`.
+- IsolationForest convention: `predict` returns `-1` for anomaly, `1` for normal;
+  `decision_function` is **higher = more normal**, so the code negates it for
+  ranking and ROC AUC. Easy to get backwards.
+
+### Feature coupling
+
+`preprocessor.extract_features` hardcodes 11 CICIDS2017 network-flow column names
+and silently drops any that are missing. Non-network artifacts therefore score on
+whatever subset happens to match — generalizing this is a known TODO.
+
+### Frontend flow
+
+`/` landing → GET STARTED → `/login` → Authenticate → `/dashboard`.
+Sidebar destinations other than `/dashboard` render a shared `ModulePlaceholder`
+that names the phase which will fill it. Unknown paths redirect to `/`.
+
+Components never call `fetch` directly: **components → services → `apiClient`**.
+`apiClient` normalizes both backend error shapes (`{error: {code, message}}` and
+`{error: "string"}`) into an `ApiError`.
+
+---
+
+## 4. Development
+
+```bash
+cd backend && pip install -r requirements.txt && python app.py
+```
+
+```bash
+cd frontend && npm install && npm run dev
+```
+
+Backend on `:5000`, frontend on `:5173`. Frontend build: `npm run build`.
+Preview a build: `npm run preview`.
+
+**There are no test, lint or type-check commands.** Nothing to run before
+committing except the frontend build, which is the only automated check that
+exists. Do not tell the user tests pass — there are none.
+
+Two requirements files: `backend/requirements.txt` is the minimal runtime set;
+root `requirements.txt` adds pymongo, reportlab, python-evtx, xmltodict for
+unbuilt phases.
+
+---
+
+## 5. Configuration
+
+**Environment variables:** the Python side reads **none** — no `os.getenv`,
+`os.environ` or dotenv usage anywhere. `.env.example` exists but is empty.
+
+The only env var in the project is frontend-side:
+
+| Variable | Purpose |
+|---|---|
+| `VITE_API_BASE_URL` | Overrides the API base. Defaults to `/api`, which Vite proxies to `http://localhost:5000`. |
+
+**Config files:** `frontend/vite.config.js` — sets the port and the `/api` proxy.
+
+**External services:** none active. CORS is wide open (`CORS(app)`). No auth, no
+database, no threat-intel API. The dataset is downloaded manually from Kaggle.
+
+---
+
+## 6. Current State
+
+### Implemented
+
+- Working `/api/health`, `/api/analyze`, `/api/evaluate` with real metrics
+  (accuracy, precision, recall, F1, per-class, confusion matrix, ROC AUC, and
+  top-10%/top-25% triage precision/recall).
+- Full preprocessing → detection → scoring pipeline for network-flow CSVs.
+- Phase 1 frontend: landing, login, dashboard, module placeholders, service
+  layer, design-token system. Verified end to end in the browser.
+
+### Not implemented (deliberately deferred)
+
+`/api/report` returns 501 · no RAW/E01 disk imaging · no EVTX, registry or PCAP
+parsing · no IOC feeds or YARA · no real auth · no PDF/JSON/CSV export · no graph
+database · no MongoDB persistence.
+
+### Known issues
+
+1. **`frontend/src/config/media.js` points the landing background video at a
+   third-party CloudFront URL** taken from the design reference. Self-host it
+   before any deployment. `CinematicBackground` falls back to a CSS gradient if
+   it fails, so this is not load-bearing.
+2. **`app.py` runs `debug=True`** — must be off for any demo or deployment.
+3. **First upload defines the cached model.** If the first `/api/analyze` call
+   receives an unrepresentative CSV, that model is pickled and reused. Delete
+   `models/isolation_forest.pkl` to retrain.
+4. **No auth on any endpoint**, and CORS allows all origins.
+5. `plan.md`'s "Current State" table says the frontend is a placeholder — stale,
+   the frontend now exists. Its target architecture also names Next.js +
+   TypeScript, which was **not** the direction taken (see below).
+
+### Decisions that should not be undone
+
+- **The frontend is Vite + React 19 + JSX with plain CSS.** `plan.md` proposes
+  Next.js + TypeScript and the old README claimed Tailwind + Recharts; both are
+  superseded. Only 3 runtime dependencies (react, react-dom, react-router-dom).
+  Charts, icons and score meters were hand-rolled rather than adding libraries.
+- **Dashboard colour policy: hue carries severity and nothing else.** The
+  `--accent*` tokens were deliberately *deleted* from `tokens.css` so accent
+  creep fails at the token level. Interaction states, focus rings, active
+  markers and progress meters are neutral greys. A red or orange element always
+  means "more serious", never "clickable". `--sev-low` and `--sev-info` are
+  colourless on purpose — nothing to decide. Do not reintroduce accent colours.
+- **Sample data must stay labelled as such.** The header comment in
+  `mockDashboard.js`, the `AiTriagePanel` footer disclaimer, and the dashboard
+  page notice ("Sample data — no evidence has been parsed") are all intentional.
+  Never present fixtures as real model output.
+- The landing page deliberately has **exactly one CTA** (GET STARTED) and no
+  fake dashboard preview, fake metrics or second login link.
+- `--sev-low` and `--sev-info` are intentionally colourless — nothing to decide.
+
+---
+
+## 7. Coding Conventions
+
+**Python (`ml/`, `backend/`)**
+
+- Classes wrap each pipeline stage; no framework abstractions.
+- Progress reported with `print("[+] ...")` in `ml/`, `logging` in `backend/`.
+  Match whichever file you are in.
+- `backend/app.py` uses `_leading_underscore` module-level helpers and returns
+  errors via `_api_error(message, status, code)`.
+- Never let an exception body reach the client — `app.py` catches, logs with
+  `logger.exception`, and returns a generic message.
+- `risk_scorer.py` uses preallocated lists/arrays and `itertuples` because it
+  runs over millions of rows. Do not rewrite as `iterrows` or `apply`.
+
+**Frontend**
+
+- One component per file, CSS co-located as `Component.css`, imported by the
+  component. Never import a stylesheet from another stylesheet — it double-inlines.
+- Token layering: `tokens.css` → `page.css` / `cinematic.css` → `global.css` →
+  component CSS. Put new shared values in `tokens.css`.
+- Mock data stays in `data/`, never inline in components.
+- Comments explain *why* a rule exists, not what it does. Follow that register.
+
+**Avoid changing**
+
+- The priority thresholds in `assign_priority` and their frontend mirrors.
+- `run_pipeline`'s 3-tuple return `(df_scaled, df_raw, df_clean)` — `app.py`
+  depends on the order.
+- The `file` form-field name — `apiClient.postFile` and the backend agree on it.
+- The `--accent*` deletion and the severity-only colour policy.
+
+---
+
+## 8. Read These First
+
+| Task | Read in this order |
+|---|---|
+| Backend / API work | `backend/app.py`, then `docs/flask_api.md` |
+| Scoring or detection logic | `ml/risk_scorer.py`, `ml/detector.py`, `docs/risk_scoring.md` |
+| New artifact types / features | `ml/preprocessor.py`, `docs/preprocessing.md`, then `RiskScorer.detect_artifact_type` |
+| Metrics / evaluation | `_evaluate_predictions` in `app.py`, `docs/evaluation_metrics.md` |
+| Frontend feature | `frontend/src/App.jsx`, the relevant `routes/` file, then `services/` |
+| Frontend styling | `frontend/src/styles/tokens.css` first — it documents the colour policy |
+| Connecting UI to backend | `services/apiClient.js`, `services/dashboardService.js`, `vite.config.js` |
+| Planning next phase | `plan.md` §2 (workstreams) and §4 (sequencing) |
+
+Skip `backend/report_generator.py` and `evaluation/evaluate.py` — both are empty.
+
+---
+
+## 9. Git / Workflow
+
+- Single `main` branch; PRs merge into it.
+- **The entire `frontend/` directory is still untracked** — it has never been
+  committed. `git status` will show it as one `??` entry.
+- Never commit datasets, `.pkl` models, or generated PDFs. `.gitignore` covers
+  `data/*.csv`, `models/*.pkl`, `reports/*.pdf`, `temp/`, `node_modules/`.
+- Before committing frontend changes, run `cd frontend && npm run build` — the
+  only automated check in the repo.

--- a/README.md
+++ b/README.md
@@ -2,39 +2,116 @@
 
 AI-assisted cyber triage tool for early-stage digital forensic analysis.
 
+Cyber Triage Tool for Digital Forensic Investigation
+(National Investigation Agency, Anti-Cyber Terrorism Division). See
+[plan.md](plan.md) for the full requirement breakdown and roadmap.
+
 ## Tech Stack
 
-- Python, Scikit-learn, Pandas (ML and processing)
-- Flask (Backend API)
-- React.js, Recharts, Tailwind (Frontend)
-- MongoDB (Database)
-- ReportLab (PDF Reports)
+**Implemented**
+
+- Python, scikit-learn, pandas — preprocessing, anomaly detection, risk scoring
+- Flask + flask-cors — backend API
+- React 19 + Vite + react-router-dom — investigator frontend
+- Plain CSS with custom properties — no CSS framework
+
+**Planned, not yet wired up** (present in the root `requirements.txt` for later phases)
+
+- ReportLab — PDF reports (`backend/report_generator.py` is still empty)
+- MongoDB / pymongo — case persistence (no code uses it yet)
+- python-evtx, xmltodict — Windows Event Log parsing
 
 ## Setup
 
 ### Backend
 
-cd backend
-pip install -r requirements.txt
-python app.py
+```bash
+cd backend && pip install -r requirements.txt && python app.py
+```
+
+Serves on `http://localhost:5000`. `backend/requirements.txt` is the minimal set
+needed to run the API; the root `requirements.txt` also includes dependencies for
+unbuilt phases.
 
 ### Frontend
 
-cd frontend
-npm install
-npm start
+```bash
+cd frontend && npm install && npm run dev
+```
+
+Serves on `http://localhost:5173`. The Vite dev server proxies `/api/*` to Flask
+on port 5000, so run the backend too if you need live data.
+
+Production build:
+
+```bash
+cd frontend && npm run build
+```
+
+## API Endpoints
+
+| Method | Endpoint        | Status                                                                      |
+| ------ | --------------- | --------------------------------------------------------------------------- |
+| GET    | `/api/health`   | Working — service liveness check                                            |
+| POST   | `/api/analyze`  | Working — upload a CSV, returns priority summary + top 100 scored artifacts |
+| POST   | `/api/evaluate` | Working — train/test split on a labeled CSV, returns classification metrics |
+| POST   | `/api/report`   | **501 stub** — not implemented                                              |
+
+`/api/analyze` and `/api/evaluate` both take a multipart upload in the form field
+named `file`. See [docs/flask_api.md](docs/flask_api.md) for request and response
+details.
+
+## Project Layout
+
+```
+backend/     Flask API (app.py) and the empty report generator stub
+ml/          Preprocessing, IsolationForest detector, risk scorer
+frontend/    React + Vite investigator UI
+docs/        Per-module design notes
+data/        Datasets (gitignored — never commit CSVs)
+models/      Persisted .pkl models (gitignored)
+reports/     Generated PDFs (gitignored)
+evaluation/  evaluate.py — currently empty
+```
+
+## How Scoring Works
+
+A CSV is cleaned and scaled, an IsolationForest produces an anomaly score, and a
+rule engine adds artifact-specific signals (failed logins, executables in temp,
+autorun registry keys, and so on). The two are combined 60/40 into a 0–100 risk
+score, which maps to a priority band:
+
+| Risk score | Priority |
+| ---------- | -------- |
+| ≥ 75       | CRITICAL |
+| ≥ 50       | HIGH     |
+| ≥ 25       | MEDIUM   |
+| < 25       | LOW      |
+
+The model trains on first use and is cached to `models/isolation_forest.pkl`.
+See [docs/risk_scoring.md](docs/risk_scoring.md) and
+[docs/anomaly_detection.md](docs/anomaly_detection.md).
 
 ## Dataset Setup
 
 This project uses the CICIDS2017 dataset.
 
-1. Download from Kaggle:-
+1. Download from Kaggle:
    https://www.kaggle.com/datasets/ericanacletoribeiro/cicids2017-cleaned-and-preprocessed
 
-2. Place the file in the data/ folder:-
-   cyber-triage-tool/data/cicids2017_cleaned.csv
+2. Place the file in the `data/` folder:
+   `cyber-triage-tool/data/cicids2017_cleaned.csv`
 
-3. The data/ folder is gitignored — never commit CSV files to this repo
+3. The `data/` folder is gitignored — never commit CSV files to this repo
+
+## Current Limitations
+
+- The frontend renders authored sample data. It is not yet connected to
+  `/api/analyze`; a service layer exists so it can be.
+- Only network-flow CSVs are supported. Disk image, registry, EVTX and PCAP
+  ingestion are not built.
+- There is no authentication. The login screen is a UI prototype only.
+- `app.py` runs with `debug=True` — turn this off before any demo or deployment.
 
 ## Contributors
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <meta name="theme-color" content="#000000" />
+    <meta name="color-scheme" content="dark" />
+    <meta
+      name="description"
+      content="Cyber Triage — accelerate digital forensic investigations with automated evidence analysis, intelligent IOC detection, and AI-powered triage."
+    />
+    <title>Cyber Triage — Digital Forensics. One Clear Investigation.</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,0 +1,918 @@
+{
+  "name": "cyber-triage-frontend",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "cyber-triage-frontend",
+      "version": "0.1.0",
+      "dependencies": {
+        "react": "^19.2.8",
+        "react-dom": "^19.2.8",
+        "react-router-dom": "^7.18.2"
+      },
+      "devDependencies": {
+        "@vitejs/plugin-react": "^6.1.0",
+        "vite": "^8.2.2"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.147.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.147.0.tgz",
+      "integrity": "sha512-IJ3s6ltHLp45S0bh7phkX+gJO7A1Wuz2EaqpAhb8WjqDwbzMiWKHhyyT42tskaWjEYXtHtVCPpnBJVT9+dcRLg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm-eabi": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm-eabi/-/binding-android-arm-eabi-1.2.6.tgz",
+      "integrity": "sha512-b+jTcARdTiFLI6jB4a5XjTm0RWd6KcRfQj/I2356fxUZemiho9zQLxo0RtCuMDAyKcLo6cEltkgbQp6d1+sjjQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.6.tgz",
+      "integrity": "sha512-lkWU8ZJaRk9q3CIEY1Tc7vIFALp3Xw5NfGJo2hQg5oIqNgxWi1zI+IiDEK3r70BF5Dzol1tcXsnzsRc8NLhG+Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.2.6.tgz",
+      "integrity": "sha512-dgR56NYnvAszm7Ob1B2/Vn0e8bUQYZH2UjVaMMtMVOCKFSfjhfLmuA/9+O+F+ajUdG6B/bSssrKW6JJYASa8jA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.2.6.tgz",
+      "integrity": "sha512-vpVxFvUCFioJqug7OTvqptkc4yb8UX0AwfDmJpaR/0sWz+BUmqSVAf7c8JkUgnN8YLspb4a/N6NhTyMAmdyQ7Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.2.6.tgz",
+      "integrity": "sha512-h1wG6Y6K3JlRswxsI64qQJqBAy4vrLuHgRbc8CZMGSWTOFRY6ghMApM1NKzB2I0n5xV1fjkE18SuVl2QpLeNpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.2.6.tgz",
+      "integrity": "sha512-tbCiqub0q2MVWJKgF5PoAlNWCtQydiOYSLIkd8sByqK/6MMYLJRcSXSYodqYtd0O+Fw7QaVmKKlS4oL94YRZ0w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.6.tgz",
+      "integrity": "sha512-oxK9+baEBPhZG5HB4URY+uU04zJWeZlH6Tb9rB5DK4DF9XR1uXNLXt5Q5ZsugTKayNCNLhkcwz/ye74hRI98dg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.6.tgz",
+      "integrity": "sha512-muWCk27FVBEZtv0MsK8gnfSmgczA8KQ0uRVJbTABKhkRfQc38aUrcb7fhi3BNiyseFmgcRsoMfQsSNJ+DbZdSw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.2.6.tgz",
+      "integrity": "sha512-eWDoSfU7Co2qj3vgB3Dt4lj1mG6CoWbcJQkRMP3XJplyCMtuaq3LHvPFjS9QIPvMGWVadJC04Xiy0IdcVPtnwQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.2.6.tgz",
+      "integrity": "sha512-2bWNjRSIayvupRKxXUY2tWG9fYdoUlTqWywHRvE8Eq3GvuQ+f2HeIkve697fIt+IQs/PV8yFsdWuhp1aJ1PdnA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.6.tgz",
+      "integrity": "sha512-KekI0gS0wLxe1UBSQSjenBVwou/JkcQPDzBPICGZjxUv9k3RteHDPBQaiOicZUFKRIH2wKEimGwVpnJsbPzu7w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.2.6.tgz",
+      "integrity": "sha512-TvtPnfVr+HtyGiDmPK4VWmlNm7QhNNAcK5Q9A7aOXsI8545yCyaoMaicXrFZ72JzeYjaUVk7yT243zT0jzjFKQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.2.6.tgz",
+      "integrity": "sha512-iOo0VEay2XFhaCcH0sps5XIimkSuOnNaZrf6+ZkoSOQBJPKNU48RkmJv0/lSpipexu5P+ouFgafe5IGr/DiQfg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.2.6.tgz",
+      "integrity": "sha512-y5NTmmasMS455JlOCO4ZM9krIchv3Mvm1crL1iUPGOPgEzSkves9n0SdC5Sjz6+qWDFhd8/JpfWMH8NSWNHe+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.2.6.tgz",
+      "integrity": "sha512-np8iZSLfXlAD4kWhiyq/u0Yt8oZDtRQ8lGhQaCXo2rl37KNjeU0GjJuwr4P3oeZ++ROfofsKNBqR5LTO8aXyWQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-6.1.0.tgz",
+      "integrity": "sha512-qd2BzUBehkov86WFhg0JkEFEYyCLG9uPCe6qWTY/kRlss9OvJrOF2UbIWT7p+8IzZHkEu0DNGHc4HSv+JdDLsw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rolldown/pluginutils": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "peerDependencies": {
+        "@rolldown/plugin-babel": "^0.1.7 || ^0.2.0",
+        "babel-plugin-react-compiler": "^1.0.0",
+        "oxc-transform-react": "^0.145.0",
+        "vite": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@rolldown/plugin-babel": {
+          "optional": true
+        },
+        "babel-plugin-react-compiler": {
+          "optional": true
+        },
+        "oxc-transform-react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz",
+      "integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.33.0",
+        "lightningcss-darwin-arm64": "1.33.0",
+        "lightningcss-darwin-x64": "1.33.0",
+        "lightningcss-freebsd-x64": "1.33.0",
+        "lightningcss-linux-arm-gnueabihf": "1.33.0",
+        "lightningcss-linux-arm64-gnu": "1.33.0",
+        "lightningcss-linux-arm64-musl": "1.33.0",
+        "lightningcss-linux-x64-gnu": "1.33.0",
+        "lightningcss-linux-x64-musl": "1.33.0",
+        "lightningcss-win32-arm64-msvc": "1.33.0",
+        "lightningcss-win32-x64-msvc": "1.33.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
+      "integrity": "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
+      "integrity": "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
+      "integrity": "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
+      "integrity": "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
+      "integrity": "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
+      "integrity": "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
+      "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
+      "integrity": "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
+      "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
+      "integrity": "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
+      "integrity": "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.7.tgz",
+      "integrity": "sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.17",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/react": {
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.8.tgz",
+      "integrity": "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.8.tgz",
+      "integrity": "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==",
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.8"
+      }
+    },
+    "node_modules/react-router": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.2.tgz",
+      "integrity": "sha512-aUVMjFm3GAPTTZL7oYr5E7ETiqfQCHRLH+B+5afnICvf0r7kkK4eR6SMuwbSTJw/7t+12khT/Kahij49fqOCIg==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.2.tgz",
+      "integrity": "sha512-AIKJ/jgGlFb3EbfCXk5Gzshiwt+l3mqbCrNjmEWMMjqQxNJ3svBa6bgzFyCC2Sw3RA0VWF1kg3uQf2OFhxb8hw==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.18.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.2.6.tgz",
+      "integrity": "sha512-vMM4q3aixf46GiF1Kok8jDPFsEpXgFWGjUHXNkNHNm+Y2adXAG2dbX91jkti3i0ZRsOlcmbuzAz1poObSHCmUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.147.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm-eabi": "1.2.6",
+        "@rolldown/binding-android-arm64": "1.2.6",
+        "@rolldown/binding-darwin-arm64": "1.2.6",
+        "@rolldown/binding-darwin-x64": "1.2.6",
+        "@rolldown/binding-freebsd-x64": "1.2.6",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.2.6",
+        "@rolldown/binding-linux-arm64-gnu": "1.2.6",
+        "@rolldown/binding-linux-arm64-musl": "1.2.6",
+        "@rolldown/binding-linux-ppc64-gnu": "1.2.6",
+        "@rolldown/binding-linux-s390x-gnu": "1.2.6",
+        "@rolldown/binding-linux-x64-gnu": "1.2.6",
+        "@rolldown/binding-linux-x64-musl": "1.2.6",
+        "@rolldown/binding-openharmony-arm64": "1.2.6",
+        "@rolldown/binding-win32-arm64-msvc": "1.2.6",
+        "@rolldown/binding-win32-x64-msvc": "1.2.6"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "license": "MIT"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/vite": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.2.2.tgz",
+      "integrity": "sha512-cFKLV/PRgAUlIRm5WjMjJ86jrftzpqcgH+Us+DS8mI3CDNiH30Whrz8uHL3+MOLPAgqbMBAqWdAHAphOAM+z/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.33.0",
+        "picomatch": "^4.0.5",
+        "postcss": "^8.5.26",
+        "rolldown": "~1.2.4",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.4.0 || ^0.5.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "cyber-triage-frontend",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "description": "Investigator frontend for the Cyber Triage digital forensics platform",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^19.2.8",
+    "react-dom": "^19.2.8",
+    "react-router-dom": "^7.18.2"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^6.1.0",
+    "vite": "^8.2.2"
+  }
+}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,0 +1,39 @@
+import { Navigate, Route, Routes } from 'react-router-dom'
+
+import LandingPage from './routes/LandingPage.jsx'
+import LoginPage from './routes/LoginPage.jsx'
+import DashboardPage from './routes/DashboardPage.jsx'
+import AppShell from './components/dashboard/AppShell.jsx'
+import ModulePlaceholder from './routes/ModulePlaceholder.jsx'
+import { NAV_ITEMS } from './data/navigation.js'
+
+/**
+ * Phase 1 routes: landing -> login -> dashboard.
+ *
+ * The remaining sidebar destinations resolve to a shared placeholder so the
+ * application shell is navigable end to end without stubbing out the later
+ * forensic modules (evidence ingestion, IOC graph, reporting, ...).
+ */
+export default function App() {
+  const laterModules = NAV_ITEMS.filter((item) => item.path !== '/dashboard')
+
+  return (
+    <Routes>
+      <Route path="/" element={<LandingPage />} />
+      <Route path="/login" element={<LoginPage />} />
+
+      <Route element={<AppShell />}>
+        <Route path="/dashboard" element={<DashboardPage />} />
+        {laterModules.map((item) => (
+          <Route
+            key={item.path}
+            path={item.path}
+            element={<ModulePlaceholder title={item.label} phase={item.phase} />}
+          />
+        ))}
+      </Route>
+
+      <Route path="*" element={<Navigate to="/" replace />} />
+    </Routes>
+  )
+}

--- a/frontend/src/components/BrandMark.jsx
+++ b/frontend/src/components/BrandMark.jsx
@@ -1,0 +1,41 @@
+/**
+ * Cyber Triage mark.
+ *
+ * Follows the reference's 25x25 clipped-disc construction (light ground, angular
+ * shards) but the geometry is our own: an aperture split into examination
+ * quadrants, with one accent shard to carry the brand colour.
+ */
+export default function BrandMark({ size = 25, className }) {
+  return (
+    <svg
+      className={className}
+      width={size}
+      height={size}
+      viewBox="0 0 25 25"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden="true"
+      focusable="false"
+    >
+      <defs>
+        <clipPath id="ct-disc">
+          <circle cx="12.5" cy="12.5" r="12.5" />
+        </clipPath>
+      </defs>
+      <g clipPath="url(#ct-disc)">
+        <rect width="25" height="25" fill="#ededed" />
+        {/* upper-left shard */}
+        <path d="M0 0h12.5L6.4 11.2 0 8.6Z" fill="#0a0b0b" />
+        {/* right sweep */}
+        <path d="M12.5 0H25v9.8l-8.9 3.1Z" fill="#050606" />
+        {/* accent shard */}
+        <path d="M25 9.8V25h-8.2l-.7-12.1Z" fill="#46b5c4" />
+        {/* lower-left counterform */}
+        <path d="M0 8.6l6.4 2.6L4.1 25H0Z" fill="#737778" />
+        {/* central aperture */}
+        <path d="M6.4 11.2l9.7 1.7.7 12.1H4.1Z" fill="#fafafa" />
+        <circle cx="12.5" cy="12.5" r="2.4" fill="#050606" />
+      </g>
+    </svg>
+  )
+}

--- a/frontend/src/components/dashboard/ActivityFeed.css
+++ b/frontend/src/components/dashboard/ActivityFeed.css
@@ -1,0 +1,84 @@
+.activity-feed {
+  display: flex;
+  flex-direction: column;
+}
+
+.activity {
+  position: relative;
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  padding: 11px 16px;
+  transition: background-color 130ms ease;
+}
+
+.activity + .activity {
+  border-top: 1px solid var(--border-subtle);
+}
+
+.activity:hover {
+  background: var(--bg-panel-raised);
+}
+
+.activity__icon {
+  display: grid;
+  place-items: center;
+  flex: none;
+  width: 24px;
+  height: 24px;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
+  background: var(--bg-inset);
+  color: var(--text-muted);
+}
+
+/* Only the two severities that change an investigator's priorities are tinted,
+   and by outline rather than fill — a feed of coloured chips reads as noise. */
+.activity__icon--critical {
+  border-color: var(--sev-critical-border);
+  color: var(--sev-critical);
+}
+
+.activity__icon--high {
+  border-color: var(--sev-high-border);
+  color: var(--sev-high);
+}
+
+.activity__body {
+  flex: 1;
+  min-width: 0;
+}
+
+.activity__message {
+  color: var(--text-primary);
+  font-size: 12px;
+  font-weight: 440;
+  line-height: 1.4;
+}
+
+.activity__meta {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  margin-top: 3px;
+  color: var(--text-muted);
+  font-size: 11px;
+  font-weight: 440;
+}
+
+.activity__case {
+  color: var(--text-secondary);
+}
+
+.activity__dot {
+  color: var(--text-faint);
+}
+
+.activity__time {
+  flex: none;
+  color: var(--text-faint);
+  font-size: 11px;
+  font-weight: 450;
+  white-space: nowrap;
+  font-variant-numeric: tabular-nums;
+}

--- a/frontend/src/components/dashboard/ActivityFeed.jsx
+++ b/frontend/src/components/dashboard/ActivityFeed.jsx
@@ -1,0 +1,46 @@
+import Icon from '../ui/Icon.jsx'
+import './ActivityFeed.css'
+
+const KIND_ICON = {
+  finding: 'alert',
+  ioc: 'shield',
+  ingest: 'evidence',
+  note: 'note',
+  escalation: 'triage',
+}
+
+/**
+ * Recent forensic events across all open cases.
+ *
+ * @param {{ events: Array<object> }} props
+ */
+export default function ActivityFeed({ events }) {
+  return (
+    <ul className="activity-feed">
+      {events.map((event) => (
+        <li key={event.id} className="activity">
+          <span
+            className={`activity__icon activity__icon--${String(event.severity).toLowerCase()}`}
+          >
+            <Icon name={KIND_ICON[event.kind] ?? 'clock'} size={13} />
+          </span>
+
+          <div className="activity__body">
+            <p className="activity__message">{event.message}</p>
+            <div className="activity__meta">
+              <span className="activity__case mono">{event.caseId}</span>
+              <span className="activity__dot" aria-hidden="true">
+                ·
+              </span>
+              <span className="activity__actor">{event.actor}</span>
+            </div>
+          </div>
+
+          <time className="activity__time" dateTime={event.at}>
+            {event.relative}
+          </time>
+        </li>
+      ))}
+    </ul>
+  )
+}

--- a/frontend/src/components/dashboard/AiTriagePanel.css
+++ b/frontend/src/components/dashboard/AiTriagePanel.css
@@ -1,0 +1,378 @@
+/* AI Triage summary. Colour appears in exactly two places — the severity meter
+   under the score and the rail on the recommended action — so both read as
+   information rather than styling. */
+
+.triage-panel {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-lg);
+  background: var(--bg-panel);
+  overflow: hidden;
+}
+
+.triage-panel__head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 13px 16px;
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.triage-panel__title {
+  color: var(--text-primary);
+  font-size: 13px;
+  font-weight: 560;
+}
+
+.triage-panel__case {
+  margin-top: 3px;
+  color: var(--text-muted);
+  font-size: 11px;
+  font-weight: 450;
+}
+
+/* ---- Score readout ------------------------------------------------------ */
+
+.triage-summary {
+  padding: 14px 16px 16px;
+  border-bottom: 1px solid var(--border-subtle);
+  background: var(--bg-inset);
+}
+
+.triage-summary__label {
+  display: block;
+  color: var(--text-muted);
+  font-size: 11px;
+  font-weight: 480;
+}
+
+.triage-score {
+  display: flex;
+  align-items: baseline;
+  gap: 4px;
+  margin-top: 4px;
+}
+
+.triage-score__value {
+  color: var(--text-primary);
+  font-size: 34px;
+  font-weight: 520;
+  letter-spacing: -0.028em;
+  line-height: 1;
+}
+
+.triage-score__max {
+  color: var(--text-faint);
+  font-size: 13px;
+  font-weight: 450;
+}
+
+/* Severity of the case, resolved once and used by the meter below. The band name
+   itself is not repeated here — it is already on the badge in the panel head. */
+.triage-summary--critical {
+  --sev: var(--sev-critical);
+}
+.triage-summary--high {
+  --sev: var(--sev-high);
+}
+.triage-summary--medium {
+  --sev: var(--sev-medium);
+}
+.triage-summary--low {
+  --sev: var(--sev-low);
+}
+
+.triage-score__meter {
+  height: 4px;
+  margin-top: 10px;
+  border-radius: var(--radius-pill);
+  background: rgba(255, 255, 255, 0.07);
+  overflow: hidden;
+}
+
+.triage-score__meter-fill {
+  display: block;
+  height: 100%;
+  border-radius: inherit;
+  background: var(--sev, var(--marker));
+}
+
+.triage-summary__stats {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 14px;
+  min-width: 0;
+  margin: 14px 0 0;
+  padding-top: 12px;
+  border-top: 1px solid var(--border-subtle);
+}
+
+.triage-stat dt {
+  color: var(--text-muted);
+  font-size: 11px;
+  font-weight: 470;
+  line-height: 1.3;
+}
+
+.triage-stat dd {
+  margin: 3px 0 0;
+  color: var(--text-primary);
+  font-size: 15px;
+  font-weight: 530;
+  letter-spacing: -0.012em;
+  line-height: 1.1;
+}
+
+.triage-stat--critical dd {
+  color: var(--sev-critical);
+}
+
+/* ---- Recommended next action -------------------------------------------- */
+
+/* Prominence comes from position and weight; the rail carries the urgency. */
+.triage-action {
+  padding: 13px 16px;
+  border-bottom: 1px solid var(--border-subtle);
+  border-left: 2px solid var(--urgency, var(--marker-dim));
+}
+
+.triage-action--critical {
+  --urgency: var(--sev-critical);
+}
+.triage-action--high {
+  --urgency: var(--sev-high);
+}
+.triage-action--medium {
+  --urgency: var(--sev-medium);
+}
+
+.triage-action__label {
+  display: block;
+  color: var(--text-muted);
+  font-size: 11px;
+  font-weight: 480;
+}
+
+.triage-action__headline {
+  margin-top: 5px;
+  color: var(--text-primary);
+  font-size: 13.5px;
+  font-weight: 520;
+  line-height: 1.35;
+}
+
+.triage-action__detail {
+  margin-top: 5px;
+  color: var(--text-secondary);
+  font-size: 12px;
+  font-weight: 430;
+  line-height: 1.45;
+}
+
+/* ---- Findings ----------------------------------------------------------- */
+
+.triage-findings__head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 16px 9px;
+}
+
+.triage-findings__count {
+  color: var(--text-faint);
+  font-size: 11px;
+}
+
+.finding {
+  display: flex;
+  align-items: flex-start;
+  gap: 11px;
+  padding: 11px 16px;
+  border-top: 1px solid var(--border-subtle);
+  transition: background-color 130ms ease;
+}
+
+.finding:hover {
+  background: var(--bg-panel-raised);
+}
+
+/* Artifact type, not severity — the badge next to the title carries that. */
+.finding__icon {
+  display: grid;
+  place-items: center;
+  flex: none;
+  width: 26px;
+  height: 26px;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
+  background: var(--bg-panel);
+  color: var(--text-muted);
+}
+
+.finding__body {
+  flex: 1;
+  min-width: 0;
+}
+
+.finding__title-line {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.finding__title {
+  color: var(--text-primary);
+  font-size: 12.5px;
+  font-weight: 520;
+}
+
+.finding__rationale {
+  margin-top: 4px;
+  color: var(--text-secondary);
+  font-size: 11.5px;
+  font-weight: 420;
+  line-height: 1.45;
+}
+
+.finding__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px 10px;
+  margin-top: 6px;
+}
+
+.finding__source,
+.finding__technique,
+.finding__observed {
+  color: var(--text-muted);
+  font-size: 10.5px;
+  font-weight: 440;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.finding__technique {
+  padding: 1px 5px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 3px;
+  color: var(--text-secondary);
+}
+
+.finding__observed {
+  font-family: var(--font-mono);
+  color: var(--text-faint);
+}
+
+.finding__score {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  flex: none;
+}
+
+.finding__score-label {
+  color: var(--text-faint);
+  font-size: 10.5px;
+  font-weight: 450;
+}
+
+.finding__score-value {
+  margin-top: 1px;
+  color: var(--text-primary);
+  font-size: 14px;
+  font-weight: 540;
+  line-height: 1.1;
+}
+
+/* ---- Footer ------------------------------------------------------------- */
+
+.triage-panel__foot {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  margin-top: auto;
+  padding: 11px 16px;
+  border-top: 1px solid var(--border-subtle);
+  background: var(--bg-inset);
+  color: var(--text-muted);
+  font-size: 10.5px;
+  font-weight: 430;
+  line-height: 1.45;
+}
+
+.triage-panel__disclaimer {
+  color: var(--text-faint);
+}
+
+/* ---- Pending state ------------------------------------------------------ */
+
+.triage-pending {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  flex: 1;
+  gap: 9px;
+  padding: 38px 26px 42px;
+  text-align: center;
+}
+
+.triage-pending__icon {
+  display: grid;
+  place-items: center;
+  width: 42px;
+  height: 42px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 50%;
+  background: var(--bg-inset);
+  color: var(--text-muted);
+}
+
+.triage-pending__headline {
+  color: var(--text-primary);
+  font-size: 13px;
+  font-weight: 520;
+}
+
+.triage-pending__detail {
+  max-width: 300px;
+  color: var(--text-muted);
+  font-size: 11.5px;
+  font-weight: 430;
+  line-height: 1.5;
+}
+
+.triage-pending__meter {
+  width: min(220px, 100%);
+  height: 3px;
+  margin-top: 5px;
+  border-radius: var(--radius-pill);
+  background: rgba(255, 255, 255, 0.07);
+  overflow: hidden;
+}
+
+.triage-pending__meter-fill {
+  display: block;
+  height: 100%;
+  border-radius: inherit;
+  background: var(--marker-dim);
+}
+
+.triage-pending__progress {
+  color: var(--text-faint);
+  font-size: 10.5px;
+  font-weight: 470;
+}
+
+/* ---- Responsive --------------------------------------------------------- */
+
+@media (max-width: 519px) {
+  .triage-summary__stats {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}

--- a/frontend/src/components/dashboard/AiTriagePanel.jsx
+++ b/frontend/src/components/dashboard/AiTriagePanel.jsx
@@ -1,0 +1,171 @@
+import Icon from '../ui/Icon.jsx'
+import SeverityBadge from '../ui/SeverityBadge.jsx'
+import { formatCount, formatPercent, formatTimestamp } from '../../utils/format.js'
+import './AiTriagePanel.css'
+
+const ARTIFACT_ICON = {
+  network: 'network',
+  file: 'file',
+  registry: 'registry',
+  system_log: 'reports',
+}
+
+/**
+ * AI Triage summary for the selected case.
+ *
+ * The score is presented as a number against a severity-scaled bar rather than a
+ * dial: the useful questions are "how high, in which band, how confident" and a
+ * ring answers none of them better than a figure does.
+ *
+ * Every finding carries a rationale line, because "why was this flagged?" is the
+ * question that decides whether an investigator trusts the ranking at all.
+ *
+ * @param {object} props
+ * @param {object|null} props.triage  `null` when the case has not been scored yet.
+ * @param {object} props.investigation Selected case, used for the pending state.
+ */
+export default function AiTriagePanel({ triage, investigation }) {
+  if (!triage) {
+    return (
+      <section className="triage-panel triage-panel--pending">
+        <header className="triage-panel__head">
+          <div>
+            <h2 className="triage-panel__title">AI Triage</h2>
+            <p className="triage-panel__case mono">{investigation?.id ?? '—'}</p>
+          </div>
+        </header>
+
+        <div className="triage-pending">
+          <span className="triage-pending__icon">
+            <Icon name="triage" size={22} />
+          </span>
+          <p className="triage-pending__headline">No triage summary yet</p>
+          <p className="triage-pending__detail">
+            {investigation?.status === 'INGESTING'
+              ? 'Evidence is still being ingested. Scoring starts once artifact extraction completes.'
+              : 'Artifacts are being correlated. The triage summary appears once scoring finishes.'}
+          </p>
+          {investigation && (
+            <div className="triage-pending__meter">
+              <span
+                className="triage-pending__meter-fill"
+                style={{ width: `${investigation.progress}%` }}
+              />
+            </div>
+          )}
+          {investigation && (
+            <p className="triage-pending__progress tabular">
+              {investigation.progress}% complete
+            </p>
+          )}
+        </div>
+      </section>
+    )
+  }
+
+  const { threatScore, severity, confidence, criticalFindings, artifactsScored, scoredAt } = triage
+  const severityClass = String(severity).toLowerCase()
+  const urgencyClass = String(triage.recommendedAction.urgency ?? severity).toLowerCase()
+
+  return (
+    <section className="triage-panel">
+      <header className="triage-panel__head">
+        <div>
+          <h2 className="triage-panel__title">AI Triage</h2>
+          <p className="triage-panel__case mono">{triage.caseId}</p>
+        </div>
+        <SeverityBadge severity={severity} />
+      </header>
+
+      {/* ---- Score readout ---- */}
+      <div className={`triage-summary triage-summary--${severityClass}`}>
+        <span className="triage-summary__label">Threat score</span>
+
+        <div className="triage-score">
+          <span className="triage-score__value tabular">{threatScore}</span>
+          <span className="triage-score__max">/100</span>
+        </div>
+
+        <div className="triage-score__meter" role="presentation">
+          <span className="triage-score__meter-fill" style={{ width: `${threatScore}%` }} />
+        </div>
+
+        <dl className="triage-summary__stats">
+          <div className="triage-stat">
+            <dt>Confidence</dt>
+            <dd className="tabular">{formatPercent(confidence)}</dd>
+          </div>
+          <div className="triage-stat triage-stat--critical">
+            <dt>Critical findings</dt>
+            <dd className="tabular">{criticalFindings}</dd>
+          </div>
+          <div className="triage-stat">
+            <dt>Artifacts scored</dt>
+            <dd className="tabular">{formatCount(artifactsScored, 'compact')}</dd>
+          </div>
+        </dl>
+      </div>
+
+      {/* ---- Recommended next action ---- */}
+      <div className={`triage-action triage-action--${urgencyClass}`}>
+        <span className="triage-action__label">Recommended next action</span>
+        <p className="triage-action__headline">{triage.recommendedAction.headline}</p>
+        <p className="triage-action__detail">{triage.recommendedAction.detail}</p>
+      </div>
+
+      {/* ---- Findings ---- */}
+      <div className="triage-findings">
+        <div className="triage-findings__head">
+          <span className="eyebrow">Top findings</span>
+          <span className="triage-findings__count mono">{triage.findings.length}</span>
+        </div>
+
+        <ul>
+          {triage.findings.map((finding) => (
+            <li key={finding.id} className="finding">
+              {/* The icon states the artifact type; the badge beside the title
+                  carries severity, so the chip itself stays neutral. */}
+              <span className="finding__icon">
+                <Icon name={ARTIFACT_ICON[finding.artifactType] ?? 'shield'} size={14} />
+              </span>
+
+              <div className="finding__body">
+                <div className="finding__title-line">
+                  <span className="finding__title">{finding.title}</span>
+                  <SeverityBadge severity={finding.severity} size="sm" />
+                </div>
+
+                <p className="finding__rationale">{finding.rationale}</p>
+
+                <div className="finding__meta">
+                  <span className="finding__source mono" title={finding.source}>
+                    {finding.source}
+                  </span>
+                  <span className="finding__technique mono" title="MITRE ATT&CK technique">
+                    {finding.technique.id} · {finding.technique.name}
+                  </span>
+                  <span className="finding__observed">{formatTimestamp(finding.observedAt)}</span>
+                </div>
+              </div>
+
+              <div className="finding__score">
+                <span className="finding__score-label">Risk</span>
+                <span className="finding__score-value tabular">{finding.riskScore}</span>
+              </div>
+            </li>
+          ))}
+        </ul>
+      </div>
+
+      <footer className="triage-panel__foot">
+        <span>
+          Sample data — scored {formatTimestamp(scoredAt)} · {triage.modelLabel}
+        </span>
+        <span className="triage-panel__disclaimer">
+          Findings on this screen are authored fixtures for UI development. The
+          detection pipeline is not connected yet.
+        </span>
+      </footer>
+    </section>
+  )
+}

--- a/frontend/src/components/dashboard/AppShell.css
+++ b/frontend/src/components/dashboard/AppShell.css
@@ -1,0 +1,48 @@
+.app-shell {
+  display: grid;
+  grid-template-columns: var(--sidebar-width) minmax(0, 1fr);
+  grid-template-rows: var(--topbar-height) minmax(0, 1fr);
+  height: 100%;
+  background: var(--bg-base);
+}
+
+.app-main {
+  grid-column: 2;
+  grid-row: 2;
+  min-width: 0;
+  overflow-y: auto;
+  background: var(--bg-base);
+}
+
+/* Overlay behind the small-screen navigation drawer. */
+.app-scrim {
+  display: none;
+  position: fixed;
+  inset: 0;
+  z-index: 18;
+  background: rgba(2, 4, 5, 0.62);
+  backdrop-filter: blur(2px);
+  cursor: default;
+}
+
+/* ---- Drawer breakpoint -------------------------------------------------- */
+
+@media (max-width: 1023px) {
+  .app-shell {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .app-main {
+    grid-column: 1;
+  }
+
+  .app-shell--drawer-open .app-scrim {
+    display: block;
+  }
+}
+
+@media (max-width: 767px) {
+  .app-shell {
+    --app-gutter: 16px;
+  }
+}

--- a/frontend/src/components/dashboard/AppShell.jsx
+++ b/frontend/src/components/dashboard/AppShell.jsx
@@ -1,0 +1,49 @@
+import { useEffect, useState } from 'react'
+import { Outlet, useLocation } from 'react-router-dom'
+
+import Sidebar from './Sidebar.jsx'
+import TopBar from './TopBar.jsx'
+import './AppShell.css'
+
+/**
+ * Investigator application shell: persistent sidebar + top bar around a scrolling
+ * content column.
+ *
+ * The landing composition is deliberately left behind here — once a case is open
+ * the interface stops being cinematic and becomes an instrument.
+ */
+export default function AppShell() {
+  const [drawerOpen, setDrawerOpen] = useState(false)
+  const { pathname } = useLocation()
+
+  // Navigating always dismisses the small-screen drawer.
+  useEffect(() => {
+    setDrawerOpen(false)
+  }, [pathname])
+
+  useEffect(() => {
+    if (!drawerOpen) return undefined
+    const onKeyDown = (event) => {
+      if (event.key === 'Escape') setDrawerOpen(false)
+    }
+    document.addEventListener('keydown', onKeyDown)
+    return () => document.removeEventListener('keydown', onKeyDown)
+  }, [drawerOpen])
+
+  return (
+    <div className={`app-shell${drawerOpen ? ' app-shell--drawer-open' : ''}`}>
+      <TopBar onToggleNav={() => setDrawerOpen((open) => !open)} navOpen={drawerOpen} />
+      <Sidebar />
+      <main className="app-main">
+        <Outlet />
+      </main>
+      <button
+        className="app-scrim"
+        type="button"
+        tabIndex={drawerOpen ? 0 : -1}
+        aria-label="Close navigation"
+        onClick={() => setDrawerOpen(false)}
+      />
+    </div>
+  )
+}

--- a/frontend/src/components/dashboard/InvestigationRow.css
+++ b/frontend/src/components/dashboard/InvestigationRow.css
@@ -1,0 +1,282 @@
+/* Rows in the primary panel: a little more room and a little more contrast than
+   the surrounding sections, since this is where triage decisions get made. */
+.inv-row {
+  position: relative;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 104px 104px auto 92px;
+  align-items: center;
+  gap: 18px;
+  padding: 15px 16px;
+  transition: background-color 130ms ease;
+}
+
+.inv-row + .inv-row {
+  border-top: 1px solid var(--border-subtle);
+}
+
+/* Severity rail on the leading edge. Always visible — scanning severity down the
+   list is the point of the column, so it does not wait for a hover. */
+.inv-row::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  width: 2px;
+  background: var(--rail, transparent);
+}
+
+.inv-row--critical {
+  --rail: var(--sev-critical);
+  --meter: var(--sev-critical);
+}
+.inv-row--high {
+  --rail: var(--sev-high);
+  --meter: var(--sev-high);
+}
+.inv-row--medium {
+  --rail: var(--sev-medium);
+  --meter: var(--sev-medium);
+}
+.inv-row--low {
+  --rail: var(--sev-low);
+  --meter: var(--sev-low);
+}
+
+.inv-row:hover {
+  background: var(--bg-panel-raised);
+}
+
+.inv-row--selected {
+  background: var(--bg-panel-raised);
+}
+
+/* Selection widens the severity rail rather than adding a second colour to it —
+   the row stays readable as "critical", just also as "the one being viewed". */
+.inv-row--selected::before {
+  width: 3px;
+}
+
+/* Full-row click target sitting behind the content. */
+.inv-row__hit {
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+}
+
+.inv-row > *:not(.inv-row__hit) {
+  position: relative;
+  z-index: 1;
+  pointer-events: none;
+}
+
+/* ---- Identity ----------------------------------------------------------- */
+
+.inv-row__identity {
+  min-width: 0;
+}
+
+.inv-row__id-line {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.inv-row__id {
+  color: var(--text-secondary);
+  font-size: 11.5px;
+  font-weight: 500;
+  letter-spacing: 0.015em;
+}
+
+/* The case description is what an investigator actually reads down the list, so
+   it carries the primary weight and the ID becomes the reference beside it. */
+.inv-row__title {
+  margin-top: 4px;
+  color: var(--text-primary);
+  font-size: 13px;
+  font-weight: 490;
+  line-height: 1.35;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.inv-row__facts {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-top: 7px;
+}
+
+.inv-row__fact {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  color: var(--text-muted);
+  font-size: 11px;
+  font-weight: 440;
+}
+
+.inv-row__fact svg {
+  color: var(--text-faint);
+}
+
+/* ---- Threat score ------------------------------------------------------- */
+
+.inv-row__score {
+  min-width: 0;
+}
+
+.inv-row__score-line {
+  display: flex;
+  align-items: baseline;
+  gap: 2px;
+}
+
+.inv-row__score-value {
+  color: var(--text-primary);
+  font-size: 19px;
+  font-weight: 560;
+  letter-spacing: -0.015em;
+  line-height: 1;
+}
+
+.inv-row__score-max {
+  color: var(--text-faint);
+  font-size: 11px;
+  font-weight: 450;
+}
+
+.inv-row__score-label {
+  display: block;
+  margin-top: 3px;
+  color: var(--text-muted);
+  font-size: 11px;
+  font-weight: 460;
+}
+
+.inv-row__meter {
+  margin-top: 7px;
+  height: 3px;
+  border-radius: var(--radius-pill);
+  background: rgba(255, 255, 255, 0.07);
+  overflow: hidden;
+}
+
+.inv-row__meter-fill {
+  display: block;
+  height: 100%;
+  border-radius: inherit;
+  background: var(--meter, var(--marker-dim));
+}
+
+/* ---- Severity + progress ------------------------------------------------ */
+
+.inv-row__severity {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 7px;
+}
+
+.inv-row__progress-label {
+  color: var(--text-muted);
+  font-size: 11px;
+  font-weight: 450;
+}
+
+/* ---- Stats -------------------------------------------------------------- */
+
+.inv-row__stats {
+  display: flex;
+  gap: 16px;
+  margin: 0;
+}
+
+.inv-row__stat {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.inv-row__stat dt {
+  color: var(--text-muted);
+  font-size: 11px;
+  font-weight: 460;
+}
+
+.inv-row__stat dd {
+  margin: 0;
+  color: var(--text-primary);
+  font-size: 13px;
+  font-weight: 520;
+}
+
+.inv-row__stat--critical dd {
+  color: var(--sev-critical);
+}
+
+/* ---- Tail --------------------------------------------------------------- */
+
+.inv-row__tail {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 6px;
+  text-align: right;
+}
+
+.inv-row__activity {
+  color: var(--text-muted);
+  font-size: 11px;
+  font-weight: 440;
+  white-space: nowrap;
+}
+
+.inv-row__chevron {
+  flex: none;
+  color: var(--text-faint);
+}
+
+/* ---- Responsive --------------------------------------------------------- */
+
+@media (max-width: 1439px) {
+  .inv-row {
+    grid-template-columns: minmax(0, 1fr) 96px auto;
+    gap: 14px;
+  }
+
+  .inv-row__severity {
+    display: none;
+  }
+
+  .inv-row__tail {
+    grid-column: 3;
+  }
+
+  .inv-row__stats {
+    grid-column: 1 / -1;
+    padding-top: 4px;
+    border-top: 1px dashed var(--border-subtle);
+  }
+}
+
+@media (max-width: 767px) {
+  .inv-row {
+    grid-template-columns: minmax(0, 1fr) auto;
+  }
+
+  .inv-row__title {
+    white-space: normal;
+  }
+
+  .inv-row__tail {
+    grid-column: 2;
+  }
+
+  .inv-row__stats {
+    flex-wrap: wrap;
+    gap: 12px 18px;
+  }
+}

--- a/frontend/src/components/dashboard/InvestigationRow.jsx
+++ b/frontend/src/components/dashboard/InvestigationRow.jsx
@@ -1,0 +1,123 @@
+import Icon from '../ui/Icon.jsx'
+import SeverityBadge, { StatusBadge } from '../ui/SeverityBadge.jsx'
+import { formatCount, formatDate } from '../../utils/format.js'
+import './InvestigationRow.css'
+
+const SEVERITY_CLASS = {
+  CRITICAL: 'critical',
+  HIGH: 'high',
+  MEDIUM: 'medium',
+  LOW: 'low',
+}
+
+/**
+ * One row in the Active Investigations list.
+ *
+ * Reads left to right as the questions an investigator opens the dashboard with:
+ * which case, how serious, how far along, what evidence is attached.
+ *
+ * @param {object} props
+ * @param {object} props.investigation
+ * @param {boolean} props.selected
+ * @param {(id: string) => void} props.onSelect
+ */
+export default function InvestigationRow({ investigation, selected, onSelect }) {
+  const {
+    id,
+    title,
+    threatScore,
+    severity,
+    status,
+    progress,
+    examiner,
+    openedAt,
+    lastActivity,
+    evidence,
+    artifacts,
+    criticalFindings,
+    iocHits,
+    primaryHost,
+  } = investigation
+
+  const severityClass = SEVERITY_CLASS[severity] ?? 'low'
+
+  return (
+    <article
+      className={`inv-row inv-row--${severityClass}${selected ? ' inv-row--selected' : ''}`}
+    >
+      <button
+        className="inv-row__hit"
+        type="button"
+        onClick={() => onSelect(id)}
+        aria-pressed={selected}
+        aria-label={`Select ${id}`}
+      />
+
+      <div className="inv-row__identity">
+        <div className="inv-row__id-line">
+          <span className="inv-row__id mono">{id}</span>
+          <StatusBadge status={status} />
+        </div>
+        <p className="inv-row__title">{title}</p>
+        <div className="inv-row__facts">
+          <span className="inv-row__fact">
+            <Icon name="host" size={12} />
+            <span className="mono">{primaryHost}</span>
+          </span>
+          <span className="inv-row__fact">
+            <Icon name="fingerprint" size={12} />
+            {examiner}
+          </span>
+          <span className="inv-row__fact">
+            <Icon name="clock" size={12} />
+            Opened {formatDate(openedAt)}
+          </span>
+        </div>
+      </div>
+
+      <div className="inv-row__score">
+        <div className="inv-row__score-line">
+          <span className="inv-row__score-value tabular">{threatScore}</span>
+          <span className="inv-row__score-max">/100</span>
+        </div>
+        <span className="inv-row__score-label">Threat score</span>
+        <div className="inv-row__meter" role="presentation">
+          <span className="inv-row__meter-fill" style={{ width: `${threatScore}%` }} />
+        </div>
+      </div>
+
+      <div className="inv-row__severity">
+        <SeverityBadge severity={severity} />
+        <span className="inv-row__progress-label">
+          <span className="tabular">{progress}%</span> triaged
+        </span>
+      </div>
+
+      <dl className="inv-row__stats">
+        <div className="inv-row__stat">
+          <dt>Evidence</dt>
+          <dd className="tabular">
+            {evidence.images + evidence.logSets + evidence.captures}
+          </dd>
+        </div>
+        <div className="inv-row__stat">
+          <dt>Artifacts</dt>
+          <dd className="tabular">{formatCount(artifacts, 'compact')}</dd>
+        </div>
+        <div className="inv-row__stat inv-row__stat--critical">
+          <dt>Critical</dt>
+          <dd className="tabular">{criticalFindings}</dd>
+        </div>
+        <div className="inv-row__stat">
+          <dt>IOCs</dt>
+          <dd className="tabular">{iocHits}</dd>
+        </div>
+      </dl>
+
+      <div className="inv-row__tail">
+        <span className="inv-row__activity">{lastActivity}</span>
+        <Icon name="chevronRight" size={15} className="inv-row__chevron" />
+      </div>
+    </article>
+  )
+}

--- a/frontend/src/components/dashboard/Panel.css
+++ b/frontend/src/components/dashboard/Panel.css
@@ -1,0 +1,72 @@
+/* Sections are defined by a hairline and a change of value, not by shadow. */
+.panel {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-lg);
+  background: var(--bg-panel);
+}
+
+.panel__head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 13px 16px;
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.panel__titles {
+  min-width: 0;
+}
+
+.panel__title {
+  color: var(--text-primary);
+  font-size: 13px;
+  font-weight: 560;
+  letter-spacing: 0.005em;
+}
+
+.panel__subtitle {
+  margin-top: 3px;
+  color: var(--text-muted);
+  font-size: 11.5px;
+  font-weight: 430;
+  line-height: 1.4;
+}
+
+.panel__action {
+  flex: none;
+}
+
+.panel__body {
+  flex: 1;
+  min-width: 0;
+  padding: 16px;
+}
+
+.panel__body--flush {
+  padding: 0;
+}
+
+/* Small text button used in panel headers. */
+.panel-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 3px 7px;
+  margin: -3px -7px;
+  border-radius: var(--radius-sm);
+  color: var(--text-secondary);
+  font-size: 11.5px;
+  font-weight: 480;
+  transition:
+    background-color 130ms ease,
+    color 130ms ease;
+}
+
+.panel-link:hover {
+  background: var(--bg-panel-hover);
+  color: var(--text-primary);
+}

--- a/frontend/src/components/dashboard/Panel.jsx
+++ b/frontend/src/components/dashboard/Panel.jsx
@@ -1,0 +1,25 @@
+import './Panel.css'
+
+/**
+ * Section container used across the application shell.
+ *
+ * @param {object} props
+ * @param {string} props.title
+ * @param {string} [props.subtitle]
+ * @param {React.ReactNode} [props.action]  Right-aligned header control.
+ * @param {boolean} [props.flush]           Removes body padding (for lists/tables).
+ */
+export default function Panel({ title, subtitle, action, flush = false, className = '', children }) {
+  return (
+    <section className={`panel ${className}`.trim()}>
+      <header className="panel__head">
+        <div className="panel__titles">
+          <h2 className="panel__title">{title}</h2>
+          {subtitle && <p className="panel__subtitle">{subtitle}</p>}
+        </div>
+        {action && <div className="panel__action">{action}</div>}
+      </header>
+      <div className={`panel__body${flush ? ' panel__body--flush' : ''}`}>{children}</div>
+    </section>
+  )
+}

--- a/frontend/src/components/dashboard/Sidebar.css
+++ b/frontend/src/components/dashboard/Sidebar.css
@@ -1,0 +1,201 @@
+.app-sidebar {
+  grid-column: 1;
+  grid-row: 2;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  min-height: 0;
+  padding: 14px 0 0;
+  border-right: 1px solid var(--border-subtle);
+  background: var(--bg-sunken);
+}
+
+/* ---- Navigation --------------------------------------------------------- */
+
+.sidebar-nav {
+  min-height: 0;
+  overflow-y: auto;
+  padding: 0 10px;
+}
+
+.sidebar-nav__section {
+  display: block;
+  padding: 0 8px 8px;
+}
+
+.sidebar-link {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 10px;
+  border-radius: var(--radius-md);
+  color: var(--text-secondary);
+  font-size: 13px;
+  font-weight: 460;
+  letter-spacing: 0.005em;
+  transition:
+    background-color 130ms ease,
+    color 130ms ease;
+}
+
+.sidebar-link + .sidebar-link,
+.app-sidebar li + li .sidebar-link {
+  margin-top: 1px;
+}
+
+.sidebar-link:hover {
+  background: var(--bg-panel);
+  color: var(--text-primary);
+}
+
+.sidebar-link--active {
+  background: var(--bg-panel-raised);
+  color: var(--text-primary);
+  font-weight: 520;
+}
+
+/* Active marker on the sunken rail. Neutral: navigation state is not severity. */
+.sidebar-link--active::before {
+  content: '';
+  position: absolute;
+  left: -10px;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 2px;
+  height: 18px;
+  border-radius: 0 2px 2px 0;
+  background: var(--marker);
+}
+
+.sidebar-link--active svg {
+  color: var(--text-primary);
+}
+
+.sidebar-link__label {
+  flex: 1;
+  min-width: 0;
+}
+
+/* Marks a destination whose module is a later phase. */
+.sidebar-link__pending {
+  flex: none;
+  width: 4px;
+  height: 4px;
+  border-radius: 50%;
+  background: var(--text-faint);
+}
+
+/* ---- Footer ------------------------------------------------------------- */
+
+.sidebar-foot {
+  flex: none;
+  padding: 12px 10px;
+}
+
+.sidebar-case {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  padding: 10px 11px;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  background: var(--bg-panel);
+}
+
+.sidebar-case__id {
+  color: var(--text-primary);
+  font-size: 12px;
+  font-weight: 520;
+  letter-spacing: 0.01em;
+}
+
+.sidebar-case__host {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  color: var(--text-muted);
+  font-size: 11px;
+  font-weight: 440;
+}
+
+.sidebar-user {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  margin-top: 10px;
+  padding: 9px 6px 2px;
+  border-top: 1px solid var(--border-subtle);
+}
+
+.sidebar-user__avatar {
+  display: grid;
+  place-items: center;
+  flex: none;
+  width: 28px;
+  height: 28px;
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-sm);
+  background: var(--bg-panel-raised);
+  color: var(--text-secondary);
+  font-size: 11px;
+  font-weight: 560;
+}
+
+.sidebar-user__meta {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-width: 0;
+  line-height: 1.3;
+}
+
+.sidebar-user__id {
+  color: var(--text-primary);
+  font-size: 12px;
+  font-weight: 520;
+}
+
+.sidebar-user__role {
+  color: var(--text-muted);
+  font-size: 11px;
+  font-weight: 440;
+}
+
+.sidebar-user__signout {
+  flex: none;
+  display: grid;
+  place-items: center;
+  width: 28px;
+  height: 28px;
+  border-radius: var(--radius-sm);
+  color: var(--text-muted);
+  transition:
+    background-color 130ms ease,
+    color 130ms ease;
+}
+
+.sidebar-user__signout:hover {
+  background: var(--bg-panel-hover);
+  color: var(--text-primary);
+}
+
+/* ---- Drawer behaviour --------------------------------------------------- */
+
+@media (max-width: 1023px) {
+  .app-sidebar {
+    position: fixed;
+    left: 0;
+    top: var(--topbar-height);
+    bottom: 0;
+    z-index: 19;
+    width: var(--sidebar-width);
+    transform: translateX(-100%);
+    transition: transform 240ms var(--ease-out-expo);
+  }
+
+  .app-shell--drawer-open .app-sidebar {
+    transform: none;
+    box-shadow: var(--shadow-raised);
+  }
+}

--- a/frontend/src/components/dashboard/Sidebar.jsx
+++ b/frontend/src/components/dashboard/Sidebar.jsx
@@ -1,0 +1,76 @@
+import { NavLink } from 'react-router-dom'
+import { useNavigate } from 'react-router-dom'
+
+import Icon from '../ui/Icon.jsx'
+import { NAV_ITEMS } from '../../data/navigation.js'
+import { getInvestigatorLabel, signOut } from '../../services/authService.js'
+import './Sidebar.css'
+
+/**
+ * Primary navigation. Destinations beyond /dashboard resolve to a placeholder
+ * that names the phase they belong to, and are marked here so the investigator
+ * can tell built from pending at a glance.
+ */
+export default function Sidebar() {
+  const navigate = useNavigate()
+  const investigator = getInvestigatorLabel()
+
+  function handleSignOut() {
+    signOut()
+    navigate('/', { replace: true })
+  }
+
+  return (
+    <aside className="app-sidebar" aria-label="Primary">
+      <nav className="sidebar-nav">
+        <span className="sidebar-nav__section eyebrow">Workspace</span>
+        <ul>
+          {NAV_ITEMS.map((item) => (
+            <li key={item.path}>
+              <NavLink
+                className={({ isActive }) =>
+                  `sidebar-link${isActive ? ' sidebar-link--active' : ''}`
+                }
+                to={item.path}
+              >
+                <Icon name={item.icon} size={17} />
+                <span className="sidebar-link__label">{item.label}</span>
+                {item.phase && <span className="sidebar-link__pending" aria-hidden="true" />}
+              </NavLink>
+            </li>
+          ))}
+        </ul>
+      </nav>
+
+      <div className="sidebar-foot">
+        <div className="sidebar-case">
+          <span className="eyebrow">Active case</span>
+          <span className="sidebar-case__id mono">CASE-2026-0147</span>
+          <span className="sidebar-case__host">
+            <Icon name="host" size={12} />
+            FIN-WKS-014
+          </span>
+        </div>
+
+        <div className="sidebar-user">
+          <span className="sidebar-user__avatar mono" aria-hidden="true">
+            {investigator.slice(-2)}
+          </span>
+          <span className="sidebar-user__meta">
+            <span className="sidebar-user__id mono">{investigator}</span>
+            <span className="sidebar-user__role">Forensic examiner</span>
+          </span>
+          <button
+            className="sidebar-user__signout"
+            type="button"
+            onClick={handleSignOut}
+            aria-label="Sign out"
+            title="Sign out"
+          >
+            <Icon name="logout" size={16} />
+          </button>
+        </div>
+      </div>
+    </aside>
+  )
+}

--- a/frontend/src/components/dashboard/StatCard.css
+++ b/frontend/src/components/dashboard/StatCard.css
@@ -1,0 +1,77 @@
+/* Supporting metric strip. Sized and toned down so the eye lands on the case
+   list below rather than here — no sparkline, no tone rail, no severity fill. */
+
+.stat-card {
+  display: flex;
+  flex-direction: column;
+  gap: 7px;
+  min-width: 0;
+  padding: 11px 13px 12px;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  background: var(--bg-panel);
+}
+
+.stat-card__label {
+  display: block;
+  color: var(--text-muted);
+  font-size: 11.5px;
+  font-weight: 480;
+  letter-spacing: 0.005em;
+}
+
+.stat-card__figure {
+  display: flex;
+  align-items: baseline;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.stat-card__value {
+  color: var(--text-primary);
+  font-size: 22px;
+  font-weight: 520;
+  letter-spacing: -0.02em;
+  line-height: 1.05;
+}
+
+/* Direction is carried by the arrow, not by colour — a rising artifact count is
+   not a severity signal. */
+.stat-card__delta {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 4px;
+  color: var(--text-muted);
+  font-size: 11px;
+  font-weight: 470;
+}
+
+.stat-card__delta-icon {
+  align-self: center;
+  color: var(--text-faint);
+  transform: rotate(-45deg);
+}
+
+.stat-card__delta--down .stat-card__delta-icon {
+  transform: rotate(45deg);
+}
+
+.stat-card__delta-period {
+  color: var(--text-faint);
+  font-weight: 430;
+}
+
+.stat-card__detail {
+  min-width: 0;
+  margin-top: auto;
+  color: var(--text-faint);
+  font-size: 11px;
+  font-weight: 430;
+  line-height: 1.4;
+}
+
+@media (max-width: 767px) {
+  .stat-card__value {
+    font-size: 20px;
+  }
+}

--- a/frontend/src/components/dashboard/StatCard.jsx
+++ b/frontend/src/components/dashboard/StatCard.jsx
@@ -1,0 +1,35 @@
+import Icon from '../ui/Icon.jsx'
+import { formatCount } from '../../utils/format.js'
+import './StatCard.css'
+
+/**
+ * Top-level dashboard metric.
+ *
+ * Deliberately plain: a number, its movement, and one line of composition. The
+ * KPI strip is context for the case list below it, not the subject of the
+ * screen, so it carries no chart, rail or tone fill.
+ *
+ * @param {{ metric: import('../../data/mockDashboard.js').DashboardMetric }} props
+ */
+export default function StatCard({ metric }) {
+  return (
+    <article className="stat-card">
+      <span className="stat-card__label">{metric.label}</span>
+
+      <div className="stat-card__figure">
+        <span className="stat-card__value tabular">
+          {formatCount(metric.value, metric.format)}
+        </span>
+        {metric.delta && (
+          <span className={`stat-card__delta stat-card__delta--${metric.delta.direction}`}>
+            <Icon name="arrowRight" size={11} strokeWidth={2} className="stat-card__delta-icon" />
+            {metric.delta.value}
+            <span className="stat-card__delta-period">{metric.delta.period}</span>
+          </span>
+        )}
+      </div>
+
+      <p className="stat-card__detail">{metric.detail}</p>
+    </article>
+  )
+}

--- a/frontend/src/components/dashboard/TopBar.css
+++ b/frontend/src/components/dashboard/TopBar.css
@@ -1,0 +1,325 @@
+.app-topbar {
+  grid-column: 1 / -1;
+  grid-row: 1;
+  z-index: 20;
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding-right: var(--app-gutter);
+  border-bottom: 1px solid var(--border-subtle);
+  background: var(--bg-sunken);
+}
+
+/* ---- Brand slot (aligned over the sidebar column) ---------------------- */
+
+.app-topbar__brand-slot {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex: none;
+  width: var(--sidebar-width);
+  height: 100%;
+  padding-left: 16px;
+  border-right: 1px solid var(--border-subtle);
+}
+
+.app-topbar__nav-toggle {
+  display: none;
+  place-items: center;
+  flex: none;
+  width: 30px;
+  height: 30px;
+  margin-left: -4px;
+  border-radius: var(--radius-sm);
+  color: var(--text-secondary);
+  transition:
+    background-color 130ms ease,
+    color 130ms ease;
+}
+
+.app-topbar__nav-toggle:hover {
+  background: var(--bg-panel);
+  color: var(--text-primary);
+}
+
+.app-topbar__brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 9px;
+  min-width: 0;
+}
+
+.app-topbar__word {
+  display: inline-flex;
+  gap: 0.32em;
+  color: #fff;
+  font-size: 13px;
+  font-weight: 570;
+  letter-spacing: 0.12em;
+  white-space: nowrap;
+}
+
+.app-topbar__word-accent {
+  color: rgba(226, 233, 234, 0.56);
+  font-weight: 420;
+}
+
+/* ---- Search ------------------------------------------------------------- */
+
+.app-topbar__search {
+  position: relative;
+  display: flex;
+  align-items: center;
+  flex: 1;
+  min-width: 0;
+  max-width: 480px;
+  height: 32px;
+  padding: 0 10px;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  background: var(--bg-panel);
+  transition:
+    border-color 150ms ease,
+    box-shadow 150ms ease;
+}
+
+.app-topbar__search:focus-within {
+  border-color: var(--border-strong);
+  box-shadow: 0 0 0 3px var(--focus-ring);
+}
+
+.app-topbar__search-icon {
+  flex: none;
+  color: var(--text-muted);
+}
+
+.app-topbar__search input {
+  flex: 1;
+  min-width: 0;
+  height: 100%;
+  padding: 0 8px;
+  border: none;
+  background: none;
+  font-size: 12.5px;
+  letter-spacing: 0.005em;
+}
+
+.app-topbar__search input::placeholder {
+  color: var(--text-faint);
+}
+
+.app-topbar__search input:focus {
+  outline: none;
+}
+
+/* Chrome/Safari clear button clashes with the dark field. */
+.app-topbar__search input::-webkit-search-cancel-button {
+  -webkit-appearance: none;
+}
+
+.app-topbar__kbd {
+  flex: none;
+  padding: 2px 5px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 4px;
+  background: var(--bg-inset);
+  color: var(--text-faint);
+  font-family: var(--font-mono);
+  font-size: 9.5px;
+  letter-spacing: 0.04em;
+}
+
+/* ---- Right cluster ------------------------------------------------------ */
+
+.app-topbar__actions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex: none;
+  margin-left: auto;
+}
+
+.app-topbar__notify {
+  position: relative;
+}
+
+.app-topbar__icon-button {
+  position: relative;
+  display: grid;
+  place-items: center;
+  width: 32px;
+  height: 32px;
+  border-radius: var(--radius-md);
+  color: var(--text-secondary);
+  transition:
+    background-color 130ms ease,
+    color 130ms ease;
+}
+
+.app-topbar__icon-button:hover {
+  background: var(--bg-panel);
+  color: var(--text-primary);
+}
+
+.app-topbar__badge {
+  position: absolute;
+  top: 2px;
+  right: 1px;
+  min-width: 14px;
+  height: 14px;
+  padding: 0 3px;
+  border-radius: var(--radius-pill);
+  background: var(--sev-critical);
+  color: #fff;
+  font-size: 9px;
+  font-weight: 650;
+  line-height: 14px;
+  text-align: center;
+  font-variant-numeric: tabular-nums;
+}
+
+/* ---- Notifications panel ------------------------------------------------ */
+
+.notify-panel {
+  position: absolute;
+  right: 0;
+  top: calc(100% + 8px);
+  z-index: 30;
+  width: 320px;
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-lg);
+  background: var(--bg-panel-raised);
+  box-shadow: var(--shadow-raised);
+  overflow: hidden;
+  animation: notify-in 160ms var(--ease-out-expo) both;
+}
+
+@keyframes notify-in {
+  from {
+    opacity: 0;
+    transform: translateY(-4px);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+
+.notify-panel__head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 12px;
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.notify-panel__count {
+  color: var(--text-muted);
+  font-size: 11px;
+}
+
+.notify-item {
+  display: flex;
+  align-items: flex-start;
+  gap: 9px;
+  padding: 10px 12px;
+}
+
+.notify-item + .notify-item {
+  border-top: 1px solid var(--border-subtle);
+}
+
+.notify-item__body {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  min-width: 0;
+}
+
+.notify-item__title {
+  color: var(--text-primary);
+  font-size: 12.5px;
+  font-weight: 450;
+  line-height: 1.35;
+}
+
+.notify-item__meta {
+  color: var(--text-muted);
+  font-size: 11px;
+}
+
+/* ---- Session indicator -------------------------------------------------- */
+
+.app-topbar__session {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  height: 32px;
+  padding: 0 11px 0 10px;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  background: var(--bg-panel);
+}
+
+/* Session presence, not a severity — plain and unlit. */
+.app-topbar__session-dot {
+  flex: none;
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: var(--marker-dim);
+}
+
+.app-topbar__session-meta {
+  display: flex;
+  flex-direction: column;
+  line-height: 1.2;
+}
+
+.app-topbar__session-id {
+  color: var(--text-primary);
+  font-size: 11.5px;
+  font-weight: 520;
+}
+
+.app-topbar__session-role {
+  color: var(--text-muted);
+  font-size: 11px;
+  font-weight: 440;
+}
+
+/* ---- Responsive --------------------------------------------------------- */
+
+@media (max-width: 1023px) {
+  .app-topbar__brand-slot {
+    width: auto;
+    border-right: none;
+    padding-left: 12px;
+  }
+
+  .app-topbar__nav-toggle {
+    display: grid;
+  }
+}
+
+@media (max-width: 767px) {
+  .app-topbar {
+    gap: 10px;
+  }
+
+  .app-topbar__word {
+    display: none;
+  }
+
+  .app-topbar__kbd {
+    display: none;
+  }
+
+  .app-topbar__session-meta {
+    display: none;
+  }
+
+  .app-topbar__session {
+    padding: 0 9px;
+  }
+}

--- a/frontend/src/components/dashboard/TopBar.jsx
+++ b/frontend/src/components/dashboard/TopBar.jsx
@@ -1,0 +1,118 @@
+import { useEffect, useRef, useState } from 'react'
+import { Link } from 'react-router-dom'
+
+import BrandMark from '../BrandMark.jsx'
+import Icon from '../ui/Icon.jsx'
+import SeverityBadge from '../ui/SeverityBadge.jsx'
+import { NOTIFICATIONS } from '../../data/mockDashboard.js'
+import { getInvestigatorLabel } from '../../services/authService.js'
+import './TopBar.css'
+
+/**
+ * Application top bar: brand, global search, notifications, session indicator.
+ *
+ * Search is a presentational input in Phase 1 — the artifact index it will query
+ * does not exist on the backend yet, so it deliberately does not pretend to
+ * return results.
+ */
+export default function TopBar({ onToggleNav, navOpen }) {
+  const [notificationsOpen, setNotificationsOpen] = useState(false)
+  const notificationsRef = useRef(null)
+  const investigator = getInvestigatorLabel()
+
+  useEffect(() => {
+    if (!notificationsOpen) return undefined
+    const onPointerDown = (event) => {
+      if (!notificationsRef.current?.contains(event.target)) setNotificationsOpen(false)
+    }
+    const onKeyDown = (event) => {
+      if (event.key === 'Escape') setNotificationsOpen(false)
+    }
+    document.addEventListener('pointerdown', onPointerDown)
+    document.addEventListener('keydown', onKeyDown)
+    return () => {
+      document.removeEventListener('pointerdown', onPointerDown)
+      document.removeEventListener('keydown', onKeyDown)
+    }
+  }, [notificationsOpen])
+
+  const unread = NOTIFICATIONS.length
+
+  return (
+    <header className="app-topbar">
+      <div className="app-topbar__brand-slot">
+        <button
+          className="app-topbar__nav-toggle"
+          type="button"
+          onClick={onToggleNav}
+          aria-expanded={navOpen}
+          aria-label={navOpen ? 'Close navigation' : 'Open navigation'}
+        >
+          <Icon name={navOpen ? 'close' : 'menu'} size={18} />
+        </button>
+
+        <Link className="app-topbar__brand" to="/dashboard">
+          <BrandMark size={22} />
+          <span className="app-topbar__word">
+            CYBER<span className="app-topbar__word-accent">TRIAGE</span>
+          </span>
+        </Link>
+      </div>
+
+      <div className="app-topbar__search">
+        <Icon name="search" size={15} className="app-topbar__search-icon" />
+        <input
+          type="search"
+          placeholder="Search cases, hosts, hashes, indicators…"
+          aria-label="Search"
+        />
+        <kbd className="app-topbar__kbd">Ctrl K</kbd>
+      </div>
+
+      <div className="app-topbar__actions">
+        <div className="app-topbar__notify" ref={notificationsRef}>
+          <button
+            className="app-topbar__icon-button"
+            type="button"
+            onClick={() => setNotificationsOpen((open) => !open)}
+            aria-expanded={notificationsOpen}
+            aria-label={`Notifications (${unread} unread)`}
+          >
+            <Icon name="bell" size={17} />
+            {unread > 0 && <span className="app-topbar__badge">{unread}</span>}
+          </button>
+
+          {notificationsOpen && (
+            <div className="notify-panel" role="dialog" aria-label="Notifications">
+              <header className="notify-panel__head">
+                <span className="eyebrow">Notifications</span>
+                <span className="notify-panel__count mono">{unread}</span>
+              </header>
+              <ul>
+                {NOTIFICATIONS.map((item) => (
+                  <li key={item.id} className="notify-item">
+                    <SeverityBadge severity={item.severity} size="sm" />
+                    <span className="notify-item__body">
+                      <span className="notify-item__title">{item.title}</span>
+                      <span className="notify-item__meta mono">
+                        {item.caseId} · {item.relative}
+                      </span>
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+        </div>
+
+        <div className="app-topbar__session" title="Active investigator session">
+          <span className="app-topbar__session-dot" aria-hidden="true" />
+          <span className="app-topbar__session-meta">
+            <span className="app-topbar__session-id mono">{investigator}</span>
+            <span className="app-topbar__session-role">Session active</span>
+          </span>
+        </div>
+      </div>
+    </header>
+  )
+}

--- a/frontend/src/components/landing/CinematicBackground.css
+++ b/frontend/src/components/landing/CinematicBackground.css
@@ -1,0 +1,78 @@
+/* Background stack for the cinematic routes. See CinematicBackground.jsx for
+   the layer order. All layers are pointer-transparent. */
+
+.cinematic-field,
+.cinematic-video,
+.cinematic-vignette,
+.cinematic-scrim {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  user-select: none;
+}
+
+/* Painted fallback: a slow cold-teal field so the composition still reads if the
+   video is blocked, offline, or replaced. */
+.cinematic-field {
+  z-index: -4;
+  background:
+    radial-gradient(ellipse 70% 55% at 22% 78%, rgba(21, 63, 72, 0.62), transparent 62%),
+    radial-gradient(ellipse 58% 48% at 76% 26%, rgba(14, 44, 58, 0.55), transparent 66%),
+    radial-gradient(ellipse 44% 40% at 62% 82%, rgba(58, 34, 24, 0.34), transparent 70%),
+    linear-gradient(168deg, #05080a 0%, #070d10 46%, #04070a 100%);
+  animation: field-drift 34s ease-in-out infinite alternate;
+}
+
+@keyframes field-drift {
+  from {
+    transform: scale(1.04) translate3d(-1.1%, -0.7%, 0);
+  }
+  to {
+    transform: scale(1.1) translate3d(1.1%, 0.9%, 0);
+  }
+}
+
+.cinematic-video {
+  z-index: -3;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  object-position: center;
+  border: none;
+}
+
+/* Reference vignette: top/bottom edge falloff plus a centre-weighted ellipse. */
+.cinematic-vignette {
+  z-index: -2;
+  background:
+    linear-gradient(
+      180deg,
+      rgba(0, 0, 0, 0.03),
+      transparent 24%,
+      transparent 82%,
+      rgba(0, 0, 0, 0.05)
+    ),
+    radial-gradient(ellipse at 44% 54%, transparent 30%, rgba(0, 0, 0, 0.055) 100%);
+}
+
+/* Login route only (`dim`): drops the whole field to a deep neutral charcoal,
+   weighted darkest at the centre so the form sits on near-black while the warm
+   footage still shows at the edges. No colour is added here — the ember tone
+   comes from the video itself. */
+.cinematic-scrim {
+  z-index: -1;
+  background:
+    radial-gradient(
+      ellipse 48% 52% at 50% 50%,
+      rgba(0, 0, 0, 0.62),
+      rgba(0, 0, 0, 0.4) 74%,
+      rgba(0, 0, 0, 0.28) 100%
+    ),
+    linear-gradient(180deg, rgba(5, 5, 6, 0.58), rgba(4, 4, 5, 0.66));
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .cinematic-field {
+    animation: none;
+  }
+}

--- a/frontend/src/components/landing/CinematicBackground.jsx
+++ b/frontend/src/components/landing/CinematicBackground.jsx
@@ -1,0 +1,51 @@
+import { useEffect, useRef, useState } from 'react'
+
+import { BACKGROUND_VIDEO_SRC, BACKGROUND_VIDEO_TYPE } from '../../config/media.js'
+import './CinematicBackground.css'
+
+/**
+ * Full-bleed background for the landing and login routes.
+ *
+ * Layers, back to front:
+ *   -4  CSS gradient field (always painted; the only visible layer if the video
+ *       never loads)
+ *   -3  looping muted video
+ *   -2  vignette
+ *   -1  optional dim scrim, used by the login route to subdue the composition
+ *
+ * @param {{ dim?: boolean }} props `dim` darkens the field for form-focused routes.
+ */
+export default function CinematicBackground({ dim = false }) {
+  const [videoFailed, setVideoFailed] = useState(false)
+  const videoRef = useRef(null)
+
+  // The dimmed variant also slows the loop. Same footage as the landing route,
+  // just less movement behind a form the investigator has to read.
+  useEffect(() => {
+    if (videoRef.current) videoRef.current.playbackRate = dim ? 0.55 : 1
+  }, [dim, videoFailed])
+
+  return (
+    <>
+      <div className="cinematic-field" aria-hidden="true" />
+      {!videoFailed && (
+        <video
+          ref={videoRef}
+          className="cinematic-video"
+          autoPlay
+          muted
+          loop
+          playsInline
+          disablePictureInPicture
+          preload="auto"
+          aria-hidden="true"
+          onError={() => setVideoFailed(true)}
+        >
+          <source src={BACKGROUND_VIDEO_SRC} type={BACKGROUND_VIDEO_TYPE} />
+        </video>
+      )}
+      <div className="cinematic-vignette" aria-hidden="true" />
+      {dim && <div className="cinematic-scrim" aria-hidden="true" />}
+    </>
+  )
+}

--- a/frontend/src/components/landing/SiteHeader.css
+++ b/frontend/src/components/landing/SiteHeader.css
@@ -1,0 +1,259 @@
+/* Landing header. Positioned absolutely inside .screen and driven by the
+   --header-top / --gutter-* tokens from cinematic.css. */
+
+.header {
+  position: absolute;
+  inset: var(--header-top) var(--gutter-end) auto var(--gutter-start);
+  z-index: 3;
+  display: flex;
+  align-items: flex-start;
+  height: 48px;
+  white-space: nowrap;
+}
+
+/* ---- Brand -------------------------------------------------------------- */
+
+.brand {
+  position: relative;
+  top: 10px;
+  display: inline-flex;
+  align-items: center;
+  gap: 9px;
+  filter: drop-shadow(0 1px 2px rgba(0, 0, 0, 0.3));
+}
+
+.brand__mark {
+  flex: none;
+}
+
+.brand__word {
+  display: inline-flex;
+  gap: 0.34em;
+  color: #fff;
+  font-size: 15px;
+  font-weight: 570;
+  letter-spacing: 0.13em;
+  text-shadow: 0 1px 3px rgba(0, 0, 0, 0.55);
+}
+
+.brand__word-accent {
+  color: rgba(226, 233, 234, 0.62);
+  font-weight: 420;
+}
+
+/* ---- Header actions cluster -------------------------------------------- */
+
+.header__actions {
+  display: flex;
+  align-items: flex-start;
+  flex: 1;
+  min-width: 0;
+}
+
+/* ---- Section labels ----------------------------------------------------- */
+
+.nav {
+  position: relative;
+  top: 9px;
+  display: flex;
+  align-items: center;
+  gap: clamp(28px, 2.9vw, 43px);
+  margin-left: clamp(30px, 3.03vw, 48px);
+}
+
+.nav__link {
+  position: relative;
+  color: rgba(229, 229, 230, 0.77);
+  font-size: 15px;
+  font-weight: 430;
+  letter-spacing: -0.022em;
+  text-shadow: 0 1px 3px rgba(0, 0, 0, 0.55);
+}
+
+.nav__link--active {
+  color: #fff;
+}
+
+.nav__link--active::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  bottom: -7px;
+  width: 44px;
+  height: 2px;
+  background: rgba(255, 255, 255, 0.82);
+}
+
+/* Non-interactive labels: no pointer affordance, slightly recessed. */
+.nav__link--upcoming {
+  color: rgba(229, 229, 230, 0.5);
+  cursor: default;
+}
+
+/* ---- System time panel -------------------------------------------------- */
+
+.status-panel {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  flex: none;
+  margin-left: auto;
+  width: 226px;
+  height: 48px;
+  padding-left: 9px;
+  border-left: 2px solid rgba(230, 230, 230, 0.52);
+}
+
+.status-panel__label {
+  color: rgba(240, 240, 240, 0.77);
+  font-size: 13px;
+  font-weight: 420;
+  letter-spacing: 0.01em;
+  text-shadow: 0 1px 3px rgba(0, 0, 0, 0.55);
+}
+
+.status-panel__value {
+  color: rgba(255, 255, 255, 0.93);
+  font-size: 13px;
+  font-weight: 440;
+  font-variant-numeric: tabular-nums;
+  text-shadow: 0 1px 3px rgba(0, 0, 0, 0.55);
+}
+
+/* ---- Menu toggle (collapsed breakpoints only) --------------------------- */
+
+.menu-toggle {
+  display: none;
+  place-items: center;
+  flex: none;
+  width: 46px;
+  height: 46px;
+  margin-left: auto;
+  border-radius: 11px;
+  color: rgba(240, 244, 245, 0.9);
+}
+
+/* ---- Entrance ----------------------------------------------------------- */
+
+[data-motion='pending'] .brand,
+[data-motion='pending'] .nav__link,
+[data-motion='pending'] .status-panel,
+[data-motion='pending'] .menu-toggle {
+  opacity: 0;
+}
+
+.brand {
+  animation: entrance-brand 580ms var(--ease-out-expo) 60ms both;
+}
+
+.nav__link {
+  animation: entrance-nav 480ms var(--ease-out-expo) both;
+}
+
+.nav__link:nth-child(1) {
+  animation-delay: 130ms;
+}
+.nav__link:nth-child(2) {
+  animation-delay: 175ms;
+}
+.nav__link:nth-child(3) {
+  animation-delay: 220ms;
+}
+.nav__link:nth-child(4) {
+  animation-delay: 265ms;
+}
+
+.status-panel {
+  animation: entrance-nav 520ms var(--ease-out-expo) 180ms both;
+}
+
+.menu-toggle {
+  animation: entrance-action 520ms var(--ease-out-expo) 140ms both;
+}
+
+/* ---- Collapsed layout (tablet + mobile) -------------------------------- */
+
+@media (max-width: 1100px) {
+  .menu-toggle {
+    display: grid;
+  }
+
+  .header__actions {
+    position: absolute;
+    right: 0;
+    top: 58px;
+    z-index: 4;
+    flex: none;
+    flex-direction: column;
+    align-items: stretch;
+    gap: 18px;
+    width: min(340px, calc(100vw - var(--gutter-start) - var(--gutter-end)));
+    padding: 20px;
+    border: 1px solid var(--glass-border-strong);
+    border-radius: 16px;
+    background: var(--glass-fill-cool);
+    box-shadow: var(--glass-shadow);
+    backdrop-filter: blur(18px) saturate(110%);
+    opacity: 0;
+    visibility: hidden;
+    transform: translateY(-8px) scale(0.985);
+    transition:
+      opacity 200ms var(--ease-out-expo),
+      transform 240ms var(--ease-out-expo),
+      visibility 240ms;
+  }
+
+  .header--menu-open .header__actions {
+    opacity: 1;
+    visibility: visible;
+    transform: none;
+  }
+
+  .nav {
+    top: 0;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 14px;
+    margin-left: 0;
+  }
+
+  .nav__link {
+    font-size: 16px;
+  }
+
+  .nav__link--active::after {
+    bottom: -5px;
+  }
+
+  .status-panel {
+    margin-left: 0;
+    width: auto;
+    height: auto;
+    padding: 10px 0 10px 10px;
+    border-top: 1px solid var(--border-subtle);
+    border-left: 2px solid rgba(230, 230, 230, 0.4);
+    border-radius: 0;
+  }
+
+  /* Inside the dropdown the items animate with the panel, not on load. */
+  .nav__link,
+  .status-panel {
+    animation: none;
+  }
+
+  [data-motion='pending'] .nav__link,
+  [data-motion='pending'] .status-panel {
+    opacity: 1;
+  }
+}
+
+@media (max-width: 619px) {
+  .brand__word {
+    font-size: 13px;
+    letter-spacing: 0.11em;
+  }
+
+  .header__actions {
+    width: min(340px, calc(100vw - var(--gutter-start) - var(--gutter-end)));
+  }
+}

--- a/frontend/src/components/landing/SiteHeader.jsx
+++ b/frontend/src/components/landing/SiteHeader.jsx
@@ -1,0 +1,93 @@
+import { useEffect, useRef, useState } from 'react'
+import { Link } from 'react-router-dom'
+
+import BrandMark from '../BrandMark.jsx'
+import Icon from '../ui/Icon.jsx'
+import './SiteHeader.css'
+
+/**
+ * Landing header: brand, section labels, system-time panel.
+ *
+ * Below 1100px the labels and panel collapse into a glass dropdown behind a
+ * hamburger, matching the reference's tablet + mobile behaviour.
+ *
+ * There is no header action: the hero's GET STARTED is the single entry point
+ * into the application, so a second login control would duplicate it.
+ *
+ * Only "Overview" is a link — the remaining labels are rendered as plain text
+ * because Phase 1 intentionally ships no additional marketing sections, and a
+ * focusable anchor that navigates nowhere is a worse affordance than a label.
+ */
+
+const SECTION_LABELS = ['Capabilities', 'Methodology', 'Contact']
+
+export default function SiteHeader() {
+  const [menuOpen, setMenuOpen] = useState(false)
+  const headerRef = useRef(null)
+  const panelRef = useRef(null)
+
+  useEffect(() => {
+    if (!menuOpen) return undefined
+
+    const onKeyDown = (event) => {
+      if (event.key === 'Escape') setMenuOpen(false)
+    }
+    const onPointerDown = (event) => {
+      if (!headerRef.current?.contains(event.target)) setMenuOpen(false)
+    }
+
+    document.addEventListener('keydown', onKeyDown)
+    document.addEventListener('pointerdown', onPointerDown)
+
+    // Move focus into the panel so the menu is keyboard-operable.
+    panelRef.current?.querySelector('a, button')?.focus()
+
+    return () => {
+      document.removeEventListener('keydown', onKeyDown)
+      document.removeEventListener('pointerdown', onPointerDown)
+    }
+  }, [menuOpen])
+
+  return (
+    <header ref={headerRef} className={`header${menuOpen ? ' header--menu-open' : ''}`}>
+      <Link className="brand" to="/" aria-label="Cyber Triage home">
+        <BrandMark size={25} className="brand__mark" />
+        <span className="brand__word">
+          CYBER<span className="brand__word-accent">TRIAGE</span>
+        </span>
+      </Link>
+
+      {/* The collapsed panel is taken out of the tab order by `visibility: hidden`
+          in the 1100px media query, so no `inert` is needed here — and an
+          unconditional one would wrongly disable the always-visible desktop nav. */}
+      <div ref={panelRef} className="header__actions" id="site-navigation">
+        <nav className="nav" aria-label="Sections">
+          <Link className="nav__link nav__link--active" to="/">
+            Overview
+          </Link>
+          {SECTION_LABELS.map((label) => (
+            <span key={label} className="nav__link nav__link--upcoming">
+              {label}
+            </span>
+          ))}
+        </nav>
+
+        <div className="status-panel">
+          <span className="status-panel__label">System Time</span>
+          <span className="status-panel__value">14:32 IST&nbsp; • &nbsp;26 August 2026</span>
+        </div>
+      </div>
+
+      <button
+        className="menu-toggle glass-cool"
+        type="button"
+        aria-expanded={menuOpen}
+        aria-controls="site-navigation"
+        aria-label={menuOpen ? 'Close menu' : 'Open menu'}
+        onClick={() => setMenuOpen((open) => !open)}
+      >
+        <Icon name={menuOpen ? 'close' : 'menu'} size={20} strokeWidth={1.6} />
+      </button>
+    </header>
+  )
+}

--- a/frontend/src/components/ui/Icon.jsx
+++ b/frontend/src/components/ui/Icon.jsx
@@ -1,0 +1,188 @@
+/**
+ * Inline icon set — stroke-based, 24x24 grid, inherits `currentColor`.
+ *
+ * Kept local rather than pulling an icon package, so the frontend stays at four
+ * dependencies. Add new glyphs to PATHS.
+ */
+
+const PATHS = {
+  dashboard: (
+    <>
+      <rect x="3" y="3" width="7.5" height="7.5" rx="1.5" />
+      <rect x="13.5" y="3" width="7.5" height="7.5" rx="1.5" />
+      <rect x="3" y="13.5" width="7.5" height="7.5" rx="1.5" />
+      <rect x="13.5" y="13.5" width="7.5" height="7.5" rx="1.5" />
+    </>
+  ),
+  cases: (
+    <>
+      <path d="M3 7.5A1.5 1.5 0 0 1 4.5 6h4l2 2.5h8A1.5 1.5 0 0 1 20 10v7.5a1.5 1.5 0 0 1-1.5 1.5h-14A1.5 1.5 0 0 1 3 17.5Z" />
+      <path d="M8 6V4.5h7V8.5" />
+    </>
+  ),
+  evidence: (
+    <>
+      <rect x="3" y="4.5" width="18" height="6" rx="1.5" />
+      <rect x="3" y="13.5" width="18" height="6" rx="1.5" />
+      <path d="M6.5 7.5h.01M6.5 16.5h.01" />
+      <path d="M10.5 7.5h4M10.5 16.5h4" />
+    </>
+  ),
+  analysis: (
+    <>
+      <path d="M4 20V9M9.33 20V4M14.67 20v-7M20 20v-9" />
+    </>
+  ),
+  triage: (
+    <>
+      <circle cx="12" cy="12" r="8" />
+      <circle cx="12" cy="12" r="3.2" />
+      <path d="M12 1.5v3M12 19.5v3M1.5 12h3M19.5 12h3" />
+    </>
+  ),
+  timeline: (
+    <>
+      <path d="M3 12h18" />
+      <circle cx="7.5" cy="12" r="2.2" />
+      <circle cx="16.5" cy="12" r="2.2" />
+      <path d="M7.5 9.8V5M16.5 14.2V19" />
+    </>
+  ),
+  graph: (
+    <>
+      <circle cx="6" cy="7" r="2.5" />
+      <circle cx="18" cy="6.5" r="2.5" />
+      <circle cx="12" cy="17.5" r="2.5" />
+      <path d="M8.2 8.3 10.4 15.4M15.9 8.2 13.6 15.5M8.4 6.6l7.2-.05" />
+    </>
+  ),
+  reports: (
+    <>
+      <path d="M6 3.5h7.5L19 9v11.5H6Z" />
+      <path d="M13 3.5V9h6" />
+      <path d="M9.5 13h7M9.5 16.5h4.5" />
+    </>
+  ),
+  search: (
+    <>
+      <circle cx="11" cy="11" r="6.5" />
+      <path d="m16 16 4.5 4.5" />
+    </>
+  ),
+  bell: (
+    <>
+      <path d="M18 9a6 6 0 1 0-12 0c0 5-2 6.5-2 6.5h16S18 14 18 9Z" />
+      <path d="M10.3 19a2 2 0 0 0 3.4 0" />
+    </>
+  ),
+  chevronDown: <path d="m6 9.5 6 5.5 6-5.5" />,
+  chevronRight: <path d="m9.5 6 5.5 6-5.5 6" />,
+  arrowRight: (
+    <>
+      <path d="M4.5 12h14" />
+      <path d="m13 6.5 5.5 5.5L13 17.5" />
+    </>
+  ),
+  alert: (
+    <>
+      <path d="M12 4.5 21 19.5H3Z" />
+      <path d="M12 10v4M12 16.8h.01" />
+    </>
+  ),
+  shield: (
+    <>
+      <path d="M12 3.5 19.5 6v6c0 4.5-3.2 7.4-7.5 8.5C7.7 19.4 4.5 16.5 4.5 12V6Z" />
+      <path d="m8.8 12 2.4 2.4 4-4.4" />
+    </>
+  ),
+  host: (
+    <>
+      <rect x="3" y="4.5" width="18" height="11.5" rx="1.5" />
+      <path d="M8.5 20h7M12 16v4" />
+    </>
+  ),
+  network: (
+    <>
+      <circle cx="12" cy="12" r="8.5" />
+      <path d="M3.5 12h17" />
+      <path d="M12 3.5c2.3 2.4 3.5 5.3 3.5 8.5S14.3 18.1 12 20.5c-2.3-2.4-3.5-5.3-3.5-8.5S9.7 5.9 12 3.5Z" />
+    </>
+  ),
+  file: (
+    <>
+      <path d="M6.5 3.5h7L18.5 8.5v12h-12Z" />
+      <path d="M13 3.5V9h5.5" />
+    </>
+  ),
+  registry: (
+    <>
+      <rect x="4" y="4" width="16" height="16" rx="1.5" />
+      <path d="M4 9h16M9 9v11" />
+      <path d="M12.5 12.5h4M12.5 16h2.5" />
+    </>
+  ),
+  clock: (
+    <>
+      <circle cx="12" cy="12" r="8.5" />
+      <path d="M12 7.5V12l3.2 2" />
+    </>
+  ),
+  note: (
+    <>
+      <path d="M5 4.5h14v10L14 20H5Z" />
+      <path d="M14 20v-5.5h5" />
+      <path d="M8.5 9h7M8.5 12.5h4" />
+    </>
+  ),
+  logout: (
+    <>
+      <path d="M14.5 4.5h-8A1.5 1.5 0 0 0 5 6v12a1.5 1.5 0 0 0 1.5 1.5h8" />
+      <path d="M15 12h5.5M18 8.5 20.5 12 18 15.5" />
+    </>
+  ),
+  menu: <path d="M3.5 8h17M3.5 16h17" />,
+  close: <path d="M6 6l12 12M18 6 6 18" />,
+  play: <path d="M9 6.5 18 12l-9 5.5Z" fill="currentColor" stroke="none" />,
+  lock: (
+    <>
+      <rect x="5" y="10.5" width="14" height="9.5" rx="1.5" />
+      <path d="M8.5 10.5V8a3.5 3.5 0 0 1 7 0v2.5" />
+    </>
+  ),
+  fingerprint: (
+    <>
+      <path d="M12 3.5c-4.7 0-8.5 3.8-8.5 8.5" />
+      <path d="M12 7c-2.8 0-5 2.2-5 5v3" />
+      <path d="M12 10.5c-.8 0-1.5.7-1.5 1.5v6" />
+      <path d="M20.5 12c0-4.7-3.8-8.5-8.5-8.5" />
+      <path d="M17 15v-3c0-2.8-2.2-5-5-5" />
+      <path d="M13.5 18v-6c0-.8-.7-1.5-1.5-1.5" />
+    </>
+  ),
+}
+
+export const ICON_NAMES = Object.keys(PATHS)
+
+export default function Icon({ name, size = 18, strokeWidth = 1.5, className, ...rest }) {
+  const glyph = PATHS[name]
+  if (!glyph) return null
+
+  return (
+    <svg
+      className={className}
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={strokeWidth}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+      focusable="false"
+      {...rest}
+    >
+      {glyph}
+    </svg>
+  )
+}

--- a/frontend/src/components/ui/SeverityBadge.css
+++ b/frontend/src/components/ui/SeverityBadge.css
@@ -1,0 +1,98 @@
+.severity-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  flex: none;
+  padding: 2px 7px 2px 6px;
+  border: 1px solid var(--border, var(--border-default));
+  border-radius: var(--radius-sm);
+  background: var(--fill, transparent);
+  color: var(--ink, var(--text-secondary));
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.severity-badge--sm {
+  padding: 1px 5px;
+  font-size: 9px;
+  letter-spacing: 0.06em;
+}
+
+.severity-badge__dot {
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: currentColor;
+}
+
+.severity-badge--critical {
+  --ink: var(--sev-critical);
+  --fill: var(--sev-critical-bg);
+  --border: var(--sev-critical-border);
+}
+
+.severity-badge--high {
+  --ink: var(--sev-high);
+  --fill: var(--sev-high-bg);
+  --border: var(--sev-high-border);
+}
+
+.severity-badge--medium {
+  --ink: var(--sev-medium);
+  --fill: var(--sev-medium-bg);
+  --border: var(--sev-medium-border);
+}
+
+.severity-badge--low {
+  --ink: var(--sev-low);
+  --fill: var(--sev-low-bg);
+  --border: var(--sev-low-border);
+}
+
+.severity-badge--info {
+  --ink: var(--sev-info);
+  --fill: var(--sev-info-bg);
+  --border: var(--sev-info-border);
+}
+
+/* ---- Case status ------------------------------------------------------- */
+/* Pipeline state is not severity. ANALYZING, CORRELATING and INGESTING all read
+   as the same quiet neutral chip — no accent hue, no pulse. ESCALATED is the one
+   status that changes what an investigator does next, so it keeps the red. */
+
+.status-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  flex: none;
+  padding: 2px 7px 2px 6px;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
+  background: var(--surface-tint);
+  color: var(--text-muted);
+  font-size: 10px;
+  font-weight: 520;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.status-badge__dot {
+  width: 4px;
+  height: 4px;
+  border-radius: 50%;
+  background: var(--text-faint);
+}
+
+.status-badge--escalated {
+  border-color: var(--sev-critical-border);
+  background: var(--sev-critical-bg);
+  color: var(--sev-critical);
+}
+
+.status-badge--escalated .status-badge__dot {
+  background: var(--sev-critical);
+}

--- a/frontend/src/components/ui/SeverityBadge.jsx
+++ b/frontend/src/components/ui/SeverityBadge.jsx
@@ -1,0 +1,33 @@
+import './SeverityBadge.css'
+
+/**
+ * Severity chip using the same bands as ml/risk_scorer.py.
+ *
+ * @param {{ severity: string, size?: 'sm'|'md', dot?: boolean }} props
+ */
+export default function SeverityBadge({ severity, size = 'md', dot = true }) {
+  if (!severity) return null
+  const key = String(severity).toLowerCase()
+
+  return (
+    <span className={`severity-badge severity-badge--${key} severity-badge--${size}`}>
+      {dot && <span className="severity-badge__dot" aria-hidden="true" />}
+      {severity}
+    </span>
+  )
+}
+
+/**
+ * Case status chip (ANALYZING, INGESTING, ...). Kept alongside SeverityBadge so
+ * pipeline state never reads as a severity level: every status renders the same
+ * neutral chip except ESCALATED, which changes what happens next.
+ */
+export function StatusBadge({ status }) {
+  if (!status) return null
+  return (
+    <span className={`status-badge status-badge--${String(status).toLowerCase()}`}>
+      <span className="status-badge__dot" aria-hidden="true" />
+      {status}
+    </span>
+  )
+}

--- a/frontend/src/config/media.js
+++ b/frontend/src/config/media.js
@@ -1,0 +1,17 @@
+/**
+ * Media configuration for the cinematic routes.
+ *
+ * `BACKGROUND_VIDEO_SRC` currently points at the asset referenced by
+ * frontend/landingpage.md, which is hosted on a third-party CloudFront
+ * distribution. Replace it with a self-hosted file (e.g. /media/triage-loop.mp4
+ * placed in frontend/public) before any deployment — an external CDN we do not
+ * control is not a dependency this page should carry.
+ *
+ * If the video fails to load, CinematicBackground falls back to a pure-CSS
+ * gradient field, so the composition never renders on flat black.
+ */
+
+export const BACKGROUND_VIDEO_SRC =
+  'https://d8j0ntlcm91z4.cloudfront.net/user_38xzZboKViGWJOttwIXH07lWA1P/hf_20260808_064556_051587f1-74a1-4336-8c05-4dde3594ed05.mp4'
+
+export const BACKGROUND_VIDEO_TYPE = 'video/mp4'

--- a/frontend/src/data/mockDashboard.js
+++ b/frontend/src/data/mockDashboard.js
@@ -1,0 +1,405 @@
+/**
+ * Mock fixtures for the Phase 1 dashboard.
+ *
+ * IMPORTANT: every value in this file is authored sample data for UI
+ * development. Nothing here was produced by a model, a parser, or a threat-intel
+ * feed. Timestamps are fixed (rather than derived from the current clock) so the
+ * dashboard renders identically on every load.
+ *
+ * Severity values match the priority bands emitted by ml/risk_scorer.py
+ * (CRITICAL >= 75, HIGH >= 50, MEDIUM >= 25, LOW otherwise) so this data stays
+ * shape-compatible with the real /api/analyze response.
+ */
+
+export const SEVERITY = {
+  CRITICAL: 'CRITICAL',
+  HIGH: 'HIGH',
+  MEDIUM: 'MEDIUM',
+  LOW: 'LOW',
+  INFO: 'INFO',
+}
+
+/**
+ * @typedef {object} DashboardMetric
+ * @property {string} id
+ * @property {string} label
+ * @property {number} value
+ * @property {'compact'|'plain'} [format]
+ * @property {string} detail
+ * @property {{ direction: 'up'|'down', value: string, period: string }} [delta]
+ */
+
+/** @type {DashboardMetric[]} */
+export const DASHBOARD_METRICS = [
+  {
+    id: 'active-investigations',
+    label: 'Active Investigations',
+    value: 7,
+    detail: '3 awaiting examiner review',
+    delta: { direction: 'up', value: '+2', period: 'this week' },
+  },
+  {
+    id: 'evidence-sources',
+    label: 'Evidence Sources',
+    value: 24,
+    detail: '9 disk images · 11 log sets · 4 captures',
+    delta: { direction: 'up', value: '+5', period: 'this week' },
+  },
+  {
+    id: 'artifacts-analyzed',
+    label: 'Artifacts Analyzed',
+    value: 1_284_907,
+    format: 'compact',
+    detail: 'Across all open cases',
+    delta: { direction: 'up', value: '+184K', period: '24h' },
+  },
+  {
+    id: 'detected-iocs',
+    label: 'Detected IOCs',
+    value: 342,
+    detail: '58 hashes · 194 addresses · 90 domains',
+    delta: { direction: 'up', value: '+27', period: '24h' },
+  },
+  {
+    id: 'critical-findings',
+    label: 'Critical Findings',
+    value: 19,
+    detail: '6 unreviewed on CASE-2026-0147',
+    delta: { direction: 'up', value: '+4', period: '24h' },
+  },
+]
+
+export const ACTIVE_INVESTIGATIONS = [
+  {
+    id: 'CASE-2026-0147',
+    title: 'Ransomware staging on finance workstation',
+    threatScore: 87,
+    severity: SEVERITY.HIGH,
+    status: 'ANALYZING',
+    progress: 68,
+    examiner: 'INV-2291',
+    openedAt: '2026-08-24T09:12:00+05:30',
+    lastActivity: '4 minutes ago',
+    evidence: { images: 2, logSets: 5, captures: 1 },
+    artifacts: 486_112,
+    criticalFindings: 6,
+    iocHits: 41,
+    primaryHost: 'FIN-WKS-014',
+  },
+  {
+    id: 'CASE-2026-0143',
+    title: 'Credential harvesting via phishing payload',
+    threatScore: 74,
+    severity: SEVERITY.HIGH,
+    status: 'CORRELATING',
+    progress: 41,
+    examiner: 'INV-2104',
+    openedAt: '2026-08-22T16:40:00+05:30',
+    lastActivity: '38 minutes ago',
+    evidence: { images: 1, logSets: 3, captures: 2 },
+    artifacts: 213_408,
+    criticalFindings: 4,
+    iocHits: 26,
+    primaryHost: 'HR-LAP-072',
+  },
+  {
+    id: 'CASE-2026-0139',
+    title: 'Unauthorised database export, night shift',
+    threatScore: 91,
+    severity: SEVERITY.CRITICAL,
+    status: 'ESCALATED',
+    progress: 92,
+    examiner: 'INV-2291',
+    openedAt: '2026-08-19T22:05:00+05:30',
+    lastActivity: '2 hours ago',
+    evidence: { images: 3, logSets: 2, captures: 1 },
+    artifacts: 391_774,
+    criticalFindings: 7,
+    iocHits: 18,
+    primaryHost: 'DB-PRD-002',
+  },
+  {
+    id: 'CASE-2026-0136',
+    title: 'Lateral movement across build agents',
+    threatScore: 52,
+    severity: SEVERITY.MEDIUM,
+    status: 'INGESTING',
+    progress: 17,
+    examiner: 'INV-2338',
+    openedAt: '2026-08-26T08:55:00+05:30',
+    lastActivity: '11 minutes ago',
+    evidence: { images: 1, logSets: 1, captures: 0 },
+    artifacts: 47_260,
+    criticalFindings: 1,
+    iocHits: 5,
+    primaryHost: 'CI-AGT-009',
+  },
+]
+
+/**
+ * Mock triage summary for the selected case. The `rationale` field is what the
+ * investigator reads to answer "why was this flagged?" — in the real pipeline it
+ * will be populated from the rule labels in ml/risk_scorer.py plus the anomaly
+ * score contribution.
+ */
+export const AI_TRIAGE = {
+  caseId: 'CASE-2026-0147',
+  threatScore: 87,
+  severity: SEVERITY.HIGH,
+  confidence: 0.92,
+  modelLabel: 'Isolation Forest + rule ensemble',
+  criticalFindings: 6,
+  artifactsScored: 486_112,
+  scoredAt: '2026-08-26T14:28:00+05:30',
+  recommendedAction: {
+    headline: 'Isolate FIN-WKS-014 and preserve volatile memory before reboot',
+    detail:
+      'Persistence is established and outbound C2 traffic is still active. Capture RAM and the Run-key hive, then contain the host before continuing artifact review.',
+    urgency: SEVERITY.CRITICAL,
+  },
+  findings: [
+    {
+      id: 'F-1042',
+      title: 'Suspicious PowerShell Execution',
+      severity: SEVERITY.CRITICAL,
+      riskScore: 94,
+      confidence: 0.96,
+      source: 'Security.evtx · Event 4688',
+      host: 'FIN-WKS-014',
+      observedAt: '2026-08-24T02:14:37+05:30',
+      technique: { id: 'T1059.001', name: 'PowerShell' },
+      rationale:
+        'Encoded command line with -nop -w hidden -enc, launched by a Word child process outside business hours.',
+      artifactType: 'system_log',
+    },
+    {
+      id: 'F-1043',
+      title: 'Malicious File Hash',
+      severity: SEVERITY.CRITICAL,
+      riskScore: 91,
+      confidence: 0.99,
+      source: 'C:\\Users\\Public\\svc_host.exe',
+      host: 'FIN-WKS-014',
+      observedAt: '2026-08-24T02:16:02+05:30',
+      technique: { id: 'T1204.002', name: 'Malicious File' },
+      rationale:
+        'SHA-256 matches a known loader family in the local signature set. Unsigned binary written to a world-writable path.',
+      artifactType: 'file',
+    },
+    {
+      id: 'F-1044',
+      title: 'Registry Persistence',
+      severity: SEVERITY.HIGH,
+      riskScore: 78,
+      confidence: 0.9,
+      source: 'NTUSER.DAT · Run\\WinUpdateSvc',
+      host: 'FIN-WKS-014',
+      observedAt: '2026-08-24T02:16:44+05:30',
+      technique: { id: 'T1547.001', name: 'Registry Run Keys' },
+      rationale:
+        'Autorun value added seconds after the loader was written, pointing at the same unsigned binary.',
+      artifactType: 'registry',
+    },
+    {
+      id: 'F-1045',
+      title: 'Unusual Network Connection',
+      severity: SEVERITY.HIGH,
+      riskScore: 71,
+      confidence: 0.84,
+      source: 'capture-014.pcap · 45.61.x.x:8443',
+      host: 'FIN-WKS-014',
+      observedAt: '2026-08-24T02:19:10+05:30',
+      technique: { id: 'T1571', name: 'Non-Standard Port' },
+      rationale:
+        'Sustained beaconing at 60s intervals to a first-seen address; flow duration and packet rate both fall in the top 1% of the baseline.',
+      artifactType: 'network',
+    },
+  ],
+}
+
+/** Second populated triage record, so case selection has more than one state. */
+export const AI_TRIAGE_0139 = {
+  caseId: 'CASE-2026-0139',
+  threatScore: 91,
+  severity: SEVERITY.CRITICAL,
+  confidence: 0.88,
+  modelLabel: 'Isolation Forest + rule ensemble',
+  criticalFindings: 7,
+  artifactsScored: 391_774,
+  scoredAt: '2026-08-26T12:22:00+05:30',
+  recommendedAction: {
+    headline: 'Revoke svc_reporting credentials and freeze the export job',
+    detail:
+      'A service account exported 4.2 GB outside its baseline window. Rotate the credential, preserve the audit log, and confirm whether the archive left the network.',
+    urgency: SEVERITY.CRITICAL,
+  },
+  findings: [
+    {
+      id: 'F-0977',
+      title: 'Bulk Row Export Outside Baseline',
+      severity: SEVERITY.CRITICAL,
+      riskScore: 96,
+      confidence: 0.94,
+      source: 'audit_log · SELECT 8.4M rows',
+      host: 'DB-PRD-002',
+      observedAt: '2026-08-19T23:41:12+05:30',
+      technique: { id: 'T1213', name: 'Data from Repositories' },
+      rationale:
+        'Single query returned 340x the account\u2019s 30-day median row count, against tables it had never previously read.',
+      artifactType: 'system_log',
+    },
+    {
+      id: 'F-0978',
+      title: 'Service Account Used Off-Hours',
+      severity: SEVERITY.HIGH,
+      riskScore: 81,
+      confidence: 0.86,
+      source: 'Security.evtx · Event 4624 (type 3)',
+      host: 'DB-PRD-002',
+      observedAt: '2026-08-19T23:38:04+05:30',
+      technique: { id: 'T1078', name: 'Valid Accounts' },
+      rationale:
+        'Interactive-style network logon for svc_reporting at 23:38 from a workstation subnet, not the scheduler host.',
+      artifactType: 'system_log',
+    },
+    {
+      id: 'F-0979',
+      title: 'Archive Staged in Temp Path',
+      severity: SEVERITY.HIGH,
+      riskScore: 76,
+      confidence: 0.91,
+      source: 'D:\\Temp\\rpt_20260819.7z (4.2 GB)',
+      host: 'DB-PRD-002',
+      observedAt: '2026-08-19T23:52:47+05:30',
+      technique: { id: 'T1074.001', name: 'Local Data Staging' },
+      rationale:
+        'Compressed archive written minutes after the export, sized to match the queried tables.',
+      artifactType: 'file',
+    },
+    {
+      id: 'F-0980',
+      title: 'Large Outbound Transfer',
+      severity: SEVERITY.CRITICAL,
+      riskScore: 89,
+      confidence: 0.82,
+      source: 'capture-db02.pcap · 443/tcp egress',
+      host: 'DB-PRD-002',
+      observedAt: '2026-08-20T00:14:29+05:30',
+      technique: { id: 'T1048', name: 'Exfiltration Over Alt Protocol' },
+      rationale:
+        'Sustained 4.1 GB upload to an external host; flow bytes/s in the top 0.2% of the network baseline.',
+      artifactType: 'network',
+    },
+  ],
+}
+
+/**
+ * Triage summaries keyed by case.
+ *
+ * Cases still INGESTING or CORRELATING map to `null` on purpose — the pipeline
+ * has not scored them yet, so the panel shows a pending state rather than
+ * inventing findings.
+ */
+export const TRIAGE_BY_CASE = {
+  'CASE-2026-0147': AI_TRIAGE,
+  'CASE-2026-0139': AI_TRIAGE_0139,
+  'CASE-2026-0143': null,
+  'CASE-2026-0136': null,
+}
+
+export const RECENT_ACTIVITY = [
+  {
+    id: 'A-9012',
+    kind: 'finding',
+    severity: SEVERITY.CRITICAL,
+    message: 'Encoded PowerShell execution flagged on FIN-WKS-014',
+    caseId: 'CASE-2026-0147',
+    actor: 'Triage engine',
+    relative: '4m ago',
+    at: '2026-08-26T14:28:00+05:30',
+  },
+  {
+    id: 'A-9011',
+    kind: 'ioc',
+    severity: SEVERITY.HIGH,
+    message: '3 new indicators extracted from capture-014.pcap',
+    caseId: 'CASE-2026-0147',
+    actor: 'Triage engine',
+    relative: '17m ago',
+    at: '2026-08-26T14:15:00+05:30',
+  },
+  {
+    id: 'A-9010',
+    kind: 'ingest',
+    severity: SEVERITY.INFO,
+    message: 'Evidence source CI-AGT-009.dd verified — SHA-256 hash match',
+    caseId: 'CASE-2026-0136',
+    actor: 'INV-2338',
+    relative: '31m ago',
+    at: '2026-08-26T14:01:00+05:30',
+  },
+  {
+    id: 'A-9009',
+    kind: 'note',
+    severity: SEVERITY.INFO,
+    message: 'Examiner note added to finding F-1044 (Registry Persistence)',
+    caseId: 'CASE-2026-0147',
+    actor: 'INV-2291',
+    relative: '52m ago',
+    at: '2026-08-26T13:40:00+05:30',
+  },
+  {
+    id: 'A-9008',
+    kind: 'escalation',
+    severity: SEVERITY.CRITICAL,
+    message: 'CASE-2026-0139 escalated to Anti-Cyber Terrorism review',
+    caseId: 'CASE-2026-0139',
+    actor: 'INV-2291',
+    relative: '2h ago',
+    at: '2026-08-26T12:30:00+05:30',
+  },
+  {
+    id: 'A-9007',
+    kind: 'finding',
+    severity: SEVERITY.HIGH,
+    message: 'Autorun key WinUpdateSvc correlated with unsigned binary',
+    caseId: 'CASE-2026-0147',
+    actor: 'Triage engine',
+    relative: '3h ago',
+    at: '2026-08-26T11:20:00+05:30',
+  },
+  {
+    id: 'A-9006',
+    kind: 'ingest',
+    severity: SEVERITY.INFO,
+    message: '5 log sets parsed from HR-LAP-072 — 213,408 artifacts scored',
+    caseId: 'CASE-2026-0143',
+    actor: 'Triage engine',
+    relative: '5h ago',
+    at: '2026-08-26T09:45:00+05:30',
+  },
+]
+
+export const NOTIFICATIONS = [
+  {
+    id: 'N-31',
+    severity: SEVERITY.CRITICAL,
+    title: 'Active C2 beaconing on FIN-WKS-014',
+    caseId: 'CASE-2026-0147',
+    relative: '4m ago',
+  },
+  {
+    id: 'N-30',
+    severity: SEVERITY.HIGH,
+    title: '6 critical findings await review',
+    caseId: 'CASE-2026-0147',
+    relative: '22m ago',
+  },
+  {
+    id: 'N-29',
+    severity: SEVERITY.INFO,
+    title: 'Ingestion complete for CI-AGT-009.dd',
+    caseId: 'CASE-2026-0136',
+    relative: '31m ago',
+  },
+]

--- a/frontend/src/data/navigation.js
+++ b/frontend/src/data/navigation.js
@@ -1,0 +1,58 @@
+/**
+ * Sidebar destinations for the investigator application shell.
+ *
+ * `phase` documents what still has to be built behind each destination — the
+ * placeholder route surfaces it so the shell is honest about what is mock and
+ * what is real.
+ */
+
+export const NAV_ITEMS = [
+  {
+    label: 'Dashboard',
+    path: '/dashboard',
+    icon: 'dashboard',
+    phase: null,
+  },
+  {
+    label: 'Cases',
+    path: '/cases',
+    icon: 'cases',
+    phase: 'Case management and chain-of-custody records',
+  },
+  {
+    label: 'Evidence',
+    path: '/evidence',
+    icon: 'evidence',
+    phase: 'Disk image, log, registry and PCAP ingestion',
+  },
+  {
+    label: 'Analysis',
+    path: '/analysis',
+    icon: 'analysis',
+    phase: 'Artifact explorer over the anomaly detection pipeline',
+  },
+  {
+    label: 'AI Triage',
+    path: '/ai-triage',
+    icon: 'triage',
+    phase: 'Ranked findings with per-artifact scoring rationale',
+  },
+  {
+    label: 'Timeline',
+    path: '/timeline',
+    icon: 'timeline',
+    phase: 'Interactive event timeline with zoom-to-second',
+  },
+  {
+    label: 'IOC Graph',
+    path: '/ioc-graph',
+    icon: 'graph',
+    phase: 'Indicator relationship graph and threat-intel enrichment',
+  },
+  {
+    label: 'Reports',
+    path: '/reports',
+    icon: 'reports',
+    phase: 'PDF, JSON and CSV export of triage findings',
+  },
+]

--- a/frontend/src/hooks/useEntranceMotion.js
+++ b/frontend/src/hooks/useEntranceMotion.js
@@ -1,0 +1,49 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+const FALLBACK_MS = 3500
+
+/**
+ * Drives the landing page's one-shot entrance choreography.
+ *
+ * While pending, the composition's elements sit at their pre-animation offsets
+ * (see LandingPage.css `[data-motion='pending']`). The last element in the
+ * timeline calls `onSettled` from its `animationend`; a fallback timer clears the
+ * state if that event never fires (e.g. the element was never painted).
+ *
+ * Users with `prefers-reduced-motion: reduce` skip the timeline entirely.
+ */
+export default function useEntranceMotion() {
+  const prefersReduced =
+    typeof window !== 'undefined' &&
+    window.matchMedia?.('(prefers-reduced-motion: reduce)').matches
+
+  const [pending, setPending] = useState(!prefersReduced)
+  const timerRef = useRef(null)
+
+  const settle = useCallback(() => {
+    if (timerRef.current) {
+      clearTimeout(timerRef.current)
+      timerRef.current = null
+    }
+    setPending(false)
+  }, [])
+
+  useEffect(() => {
+    if (!pending) return undefined
+
+    timerRef.current = setTimeout(settle, FALLBACK_MS)
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current)
+    }
+    // Intentionally only on mount: the fallback should not restart on re-render.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  return {
+    /** Spread onto the composition root. */
+    motionProps: { 'data-motion': pending ? 'pending' : 'settled' },
+    /** Attach to the final element in the timeline. */
+    onSettled: settle,
+    pending,
+  }
+}

--- a/frontend/src/hooks/useRouteMode.js
+++ b/frontend/src/hooks/useRouteMode.js
@@ -1,0 +1,28 @@
+import { useEffect } from 'react'
+
+/**
+ * Marks the document with a route mode so global CSS can react to it.
+ *
+ * The landing and login routes are fixed full-viewport compositions with no page
+ * scroll; the application shell scrolls normally. Rather than locking overflow
+ * globally, each cinematic route declares itself and releases the lock on unmount.
+ *
+ * @param {'cinematic'|null} mode
+ */
+export default function useRouteMode(mode) {
+  useEffect(() => {
+    if (!mode) return undefined
+
+    const root = document.documentElement
+    const previous = root.dataset.routeMode
+    root.dataset.routeMode = mode
+
+    return () => {
+      if (previous) {
+        root.dataset.routeMode = previous
+      } else {
+        delete root.dataset.routeMode
+      }
+    }
+  }, [mode])
+}

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,0 +1,15 @@
+import React from 'react'
+import { createRoot } from 'react-dom/client'
+import { BrowserRouter } from 'react-router-dom'
+
+import App from './App.jsx'
+import './styles/tokens.css'
+import './styles/global.css'
+
+createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
+  </React.StrictMode>,
+)

--- a/frontend/src/routes/DashboardPage.css
+++ b/frontend/src/routes/DashboardPage.css
@@ -1,0 +1,94 @@
+.dashboard--loading {
+  align-items: center;
+  justify-content: center;
+  min-height: 40vh;
+}
+
+.dashboard__loading-text {
+  color: var(--text-muted);
+  font-size: 12px;
+  font-weight: 450;
+}
+
+/* ---- Metrics ------------------------------------------------------------ */
+
+/* Supporting context above the case list, not the headline of the screen. */
+.metric-grid {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: 10px;
+}
+
+/* ---- Body layout -------------------------------------------------------- */
+
+.dashboard__grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) clamp(352px, 26vw, 428px);
+  grid-template-areas:
+    'cases triage'
+    'activity triage';
+  align-items: start;
+  gap: 16px;
+}
+
+.dashboard__cases {
+  grid-area: cases;
+  /* Primary panel: a firmer hairline and a heavier header than its siblings, so
+     the case list reads as the subject of the screen without being recoloured. */
+  border-color: var(--border-default);
+}
+
+.dashboard__cases .panel__head {
+  padding: 15px 16px 14px;
+}
+
+.dashboard__cases .panel__title {
+  font-size: 14.5px;
+  font-weight: 540;
+}
+
+.dashboard__triage {
+  grid-area: triage;
+  display: flex;
+  min-width: 0;
+}
+
+.dashboard__triage > * {
+  flex: 1;
+}
+
+.dashboard__activity {
+  grid-area: activity;
+}
+
+/* ---- Responsive --------------------------------------------------------- */
+
+@media (max-width: 1439px) {
+  .metric-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+/* The triage summary drops below the case list rather than beside it, and stays
+   above Recent Activity — it answers the more urgent question. */
+@media (max-width: 1279px) {
+  .dashboard__grid {
+    grid-template-columns: minmax(0, 1fr);
+    grid-template-areas:
+      'cases'
+      'triage'
+      'activity';
+  }
+}
+
+@media (max-width: 1023px) {
+  .metric-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 519px) {
+  .metric-grid {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}

--- a/frontend/src/routes/DashboardPage.jsx
+++ b/frontend/src/routes/DashboardPage.jsx
@@ -1,0 +1,151 @@
+import { useEffect, useMemo, useState } from 'react'
+import { Link } from 'react-router-dom'
+import Panel from '../components/dashboard/Panel.jsx'
+import StatCard from '../components/dashboard/StatCard.jsx'
+import InvestigationRow from '../components/dashboard/InvestigationRow.jsx'
+import AiTriagePanel from '../components/dashboard/AiTriagePanel.jsx'
+import ActivityFeed from '../components/dashboard/ActivityFeed.jsx'
+import Icon from '../components/ui/Icon.jsx'
+import {
+  fetchActiveInvestigations,
+  fetchDashboardMetrics,
+  fetchRecentActivity,
+  fetchTriageSummary,
+} from '../services/dashboardService.js'
+import { formatTimestamp } from '../utils/format.js'
+import '../styles/page.css'
+import './DashboardPage.css'
+
+export default function DashboardPage() {
+  const [metrics, setMetrics] = useState([])
+  const [investigations, setInvestigations] = useState([])
+  const [activity, setActivity] = useState([])
+  const [selectedCaseId, setSelectedCaseId] = useState(null)
+  const [triage, setTriage] = useState(null)
+  const [ready, setReady] = useState(false)
+
+  // Initial load. Everything comes through the service layer, so swapping the
+  // mock fixtures for the Flask API later touches only services/.
+  useEffect(() => {
+    let cancelled = false
+
+    Promise.all([
+      fetchDashboardMetrics(),
+      fetchActiveInvestigations(),
+      fetchRecentActivity(),
+    ]).then(([nextMetrics, nextInvestigations, nextActivity]) => {
+      if (cancelled) return
+      setMetrics(nextMetrics)
+      setInvestigations(nextInvestigations)
+      setActivity(nextActivity)
+      setSelectedCaseId(nextInvestigations[0]?.id ?? null)
+      setReady(true)
+    })
+
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  // Triage summary follows the selected case.
+  useEffect(() => {
+    if (!selectedCaseId) return undefined
+    let cancelled = false
+
+    fetchTriageSummary(selectedCaseId).then((summary) => {
+      if (!cancelled) setTriage(summary)
+    })
+
+    return () => {
+      cancelled = true
+    }
+  }, [selectedCaseId])
+
+  const selected = useMemo(
+    () => investigations.find((item) => item.id === selectedCaseId) ?? null,
+    [investigations, selectedCaseId],
+  )
+
+  if (!ready) {
+    return (
+      <div className="page dashboard dashboard--loading" role="status">
+        <span className="dashboard__loading-text">Loading investigation overview…</span>
+      </div>
+    )
+  }
+
+  return (
+    <div className="page dashboard">
+      <header className="page-head">
+        <div className="page-head__titles">
+          <h1 className="page-head__title">Investigation overview</h1>
+          <p className="page-head__subtitle">
+            {investigations.length} open cases assigned to this workspace
+            {triage && (
+              <>
+                {' · '}
+                <span className="page-head__sync">
+                  last pipeline sync {formatTimestamp(triage.scoredAt)}
+                </span>
+              </>
+            )}
+          </p>
+        </div>
+
+        <span className="page-head__notice">
+          <Icon name="alert" size={12} strokeWidth={1.7} />
+          Sample data — no evidence has been parsed
+        </span>
+      </header>
+
+      <section className="metric-grid" aria-label="Case metrics">
+        {metrics.map((metric) => (
+          <StatCard key={metric.id} metric={metric} />
+        ))}
+      </section>
+
+      <div className="dashboard__grid">
+        <Panel
+          className="dashboard__cases"
+          title="Active Investigations"
+          subtitle="Select a case to load its triage summary"
+          action={
+            <Link className="panel-link" to="/cases">
+              All cases
+              <Icon name="chevronRight" size={13} />
+            </Link>
+          }
+          flush
+        >
+          {investigations.map((investigation) => (
+            <InvestigationRow
+              key={investigation.id}
+              investigation={investigation}
+              selected={investigation.id === selectedCaseId}
+              onSelect={setSelectedCaseId}
+            />
+          ))}
+        </Panel>
+
+        <div className="dashboard__triage">
+          <AiTriagePanel triage={triage} investigation={selected} />
+        </div>
+
+        <Panel
+          className="dashboard__activity"
+          title="Recent Activity"
+          subtitle="Across all open cases"
+          action={
+            <Link className="panel-link" to="/timeline">
+              Full timeline
+              <Icon name="chevronRight" size={13} />
+            </Link>
+          }
+          flush
+        >
+          <ActivityFeed events={activity} />
+        </Panel>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/routes/LandingPage.css
+++ b/frontend/src/routes/LandingPage.css
@@ -1,0 +1,205 @@
+/* Landing composition: bottom-left hero stack over the cinematic background.
+   Layout tokens come from cinematic.css. */
+
+.hero {
+  position: absolute;
+  inset: 0;
+  z-index: 2;
+  pointer-events: none;
+}
+
+.hero > * {
+  pointer-events: auto;
+}
+
+/* ---- Hero stack --------------------------------------------------------- */
+
+.hero-content {
+  position: absolute;
+  left: var(--gutter-start);
+  bottom: var(--hero-bottom);
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  max-width: calc(100% - var(--gutter-start) - var(--gutter-end));
+}
+
+.hero-title {
+  font-family: var(--font-display);
+  font-optical-sizing: auto;
+  font-size: var(--display-size);
+  font-weight: 500;
+  line-height: var(--display-leading);
+  letter-spacing: -0.024em;
+  white-space: nowrap;
+  text-shadow: 0 2px 2px rgba(0, 0, 0, 0.44);
+  -webkit-text-stroke: 0.12px currentColor;
+}
+
+.line {
+  display: block;
+  overflow: hidden;
+  transform-origin: left center;
+}
+
+.line-reveal {
+  display: block;
+  will-change: transform;
+}
+
+.line-one {
+  color: #fff;
+  transform: scaleX(0.775);
+}
+
+.line-two {
+  color: rgba(211, 207, 207, 0.78);
+  transform: scaleX(0.793);
+}
+
+.hero-copy {
+  position: relative;
+  left: 1px;
+  width: clamp(340px, 42vw, 575px);
+  max-width: 100%;
+  margin-top: var(--title-copy-gap);
+  color: rgba(226, 229, 228, 0.84);
+  font-size: var(--copy-size);
+  font-weight: 350;
+  line-height: var(--copy-leading);
+  letter-spacing: 0.13px;
+  text-shadow: 0 1px 3px rgba(0, 0, 0, 0.7);
+}
+
+.hero-actions {
+  display: flex;
+  align-items: center;
+  margin-top: var(--copy-cta-gap);
+}
+
+/* ---- Primary CTA (white pill + dark arrow box) -------------------------- */
+/* The only call to action on the page. Login is reached through it, not beside
+   it, so there is a single entry path into the application. */
+
+.primary-cta {
+  position: relative;
+  flex: none;
+  width: var(--cta-width);
+  height: var(--cta-height);
+  border-radius: 7px;
+  background: #fff;
+  color: #111;
+  box-shadow: 0 1px 5px rgba(0, 0, 0, 0.38);
+}
+
+.primary-cta__label {
+  position: absolute;
+  left: 8.125%;
+  top: 50%;
+  transform: translateY(-50%);
+  font-size: clamp(11px, 1.24vh, 13px);
+  font-weight: 560;
+  letter-spacing: 0.075em;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.primary-cta__arrow {
+  position: absolute;
+  right: 3.125%;
+  top: 14.286%;
+  display: grid;
+  place-items: center;
+  width: 20.625%;
+  height: 71.429%;
+  border-radius: 7px;
+  background: #070909;
+  color: #fff;
+}
+
+/* ---- Entrance ----------------------------------------------------------- */
+
+[data-motion='pending'] .line-reveal {
+  transform: translate3d(0, 110%, 0) skewY(2deg);
+}
+
+[data-motion='pending'] .hero-copy,
+[data-motion='pending'] .hero-actions {
+  opacity: 0;
+}
+
+.line-one .line-reveal {
+  animation: entrance-line 800ms var(--ease-out-quint) 300ms both;
+}
+
+.line-two .line-reveal {
+  animation: entrance-line 850ms var(--ease-out-quint) 440ms both;
+}
+
+.hero-copy {
+  animation: entrance-copy 620ms var(--ease-out-expo) 740ms both;
+}
+
+.hero-actions {
+  animation: entrance-action 560ms var(--ease-out-expo) 960ms both;
+}
+
+/* ---- Collapsed breakpoints --------------------------------------------- */
+
+/* Below the desktop breakpoint the hard line breaks in the body copy fight the
+   narrower measure, so natural wrapping takes over (as in the reference). */
+@media (max-width: 1100px) {
+  .hero-copy {
+    width: min(520px, 62vw);
+  }
+
+  .hero-copy br {
+    display: none;
+  }
+}
+
+@media (max-width: 860px) {
+  .hero-title {
+    letter-spacing: -0.02em;
+  }
+
+  .hero-copy {
+    width: min(460px, 74vw);
+  }
+}
+
+/* Mobile: the headline wraps instead of squashing. */
+@media (max-width: 619px) {
+  .screen.landing {
+    --display-size: clamp(30px, 8.7vw, 48px);
+    --display-leading: clamp(36px, 10.4vw, 56px);
+    --hero-bottom: max(28px, env(safe-area-inset-bottom, 0px) + 24px);
+  }
+
+  .hero-title {
+    white-space: normal;
+  }
+
+  .line-one {
+    transform: scaleX(0.94);
+  }
+
+  .line-two {
+    transform: scaleX(0.95);
+  }
+
+  .hero-copy {
+    width: 100%;
+    max-width: 92vw;
+  }
+
+  .hero-actions {
+    width: 100%;
+  }
+
+  .primary-cta {
+    flex: 1 1 auto;
+    min-width: 160px;
+    max-width: 260px;
+  }
+}

--- a/frontend/src/routes/LandingPage.jsx
+++ b/frontend/src/routes/LandingPage.jsx
@@ -1,0 +1,67 @@
+import { Link } from 'react-router-dom'
+
+import CinematicBackground from '../components/landing/CinematicBackground.jsx'
+import SiteHeader from '../components/landing/SiteHeader.jsx'
+import Icon from '../components/ui/Icon.jsx'
+import useEntranceMotion from '../hooks/useEntranceMotion.js'
+import useRouteMode from '../hooks/useRouteMode.js'
+import '../styles/cinematic.css'
+import './LandingPage.css'
+
+/**
+ * Landing route.
+ *
+ * Composition is deliberately minimal: cinematic background, header, hero stack,
+ * one CTA. No case data, metrics, or dashboard preview appears before login —
+ * the investigation surface starts at /dashboard.
+ */
+export default function LandingPage() {
+  useRouteMode('cinematic')
+  const { motionProps, onSettled } = useEntranceMotion()
+
+  return (
+    <main className="viewport">
+      <section className="screen landing" {...motionProps}>
+        <CinematicBackground />
+        <SiteHeader />
+
+        <section className="hero">
+          <div className="hero-content">
+            <h1 className="hero-title">
+              <span className="line line-one">
+                <span className="line-reveal">Digital Forensics.</span>
+              </span>
+              <span className="line line-two">
+                <span className="line-reveal">Clear Answers. Faster.</span>
+              </span>
+            </h1>
+
+            <p className="hero-copy">
+              Accelerate digital forensic investigations with automated
+              <br />
+              evidence analysis, intelligent IOC detection, AI-powered
+              <br />
+              triage, and investigator-focused visualization.
+            </p>
+
+            {/* Last element in the entrance timeline, so it closes out the
+                choreography for useEntranceMotion. */}
+            <div
+              className="hero-actions"
+              onAnimationEnd={(event) => {
+                if (event.animationName === 'entrance-action') onSettled()
+              }}
+            >
+              <Link className="primary-cta" to="/login">
+                <span className="primary-cta__label">Get Started</span>
+                <span className="primary-cta__arrow" aria-hidden="true">
+                  <Icon name="arrowRight" size={14} strokeWidth={1.7} />
+                </span>
+              </Link>
+            </div>
+          </div>
+        </section>
+      </section>
+    </main>
+  )
+}

--- a/frontend/src/routes/LoginPage.css
+++ b/frontend/src/routes/LoginPage.css
@@ -1,0 +1,279 @@
+/**
+ * Investigator sign-in.
+ *
+ * Same background footage and type system as the landing route, held back: the
+ * video is darkened and de-saturated, and the panel is a charcoal surface with a
+ * neutral hairline border — no coloured glow, no accent tinting, no HUD framing.
+ * The only bright element on the screen is the submit button, which is the same
+ * white pill as the landing CTA.
+ *
+ * The overrides below are scoped to `.screen.login`, so the landing composition
+ * is untouched.
+ */
+
+/* ---- Background: darker and quieter than the landing route --------------- */
+
+.screen.login .cinematic-video {
+  /* Pulled well down and de-saturated so the footage reads as atmosphere behind
+     the form rather than as the subject. Slight scale hides the blur edge. */
+  filter: brightness(0.62) saturate(0.8) contrast(0.94) blur(2px);
+  transform: scale(1.05);
+}
+
+/* Fallback field (only visible if the video is blocked): warm neutral, matching
+   the footage's ember tone instead of the landing fallback's cold cast. */
+.screen.login .cinematic-field {
+  background:
+    radial-gradient(ellipse 68% 54% at 50% 64%, rgba(72, 30, 16, 0.46), transparent 68%),
+    radial-gradient(ellipse 52% 44% at 26% 22%, rgba(38, 22, 16, 0.4), transparent 70%),
+    linear-gradient(172deg, #0a0908 0%, #0c0a09 48%, #060606 100%);
+  animation-duration: 58s;
+}
+
+/* ---- Layout ------------------------------------------------------------- */
+
+.login-layout {
+  position: relative;
+  z-index: 2;
+  display: grid;
+  place-items: center;
+  width: 100%;
+  height: 100%;
+  padding: 24px;
+  overflow-y: auto;
+}
+
+/* ---- Panel -------------------------------------------------------------- */
+
+.login-panel {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  max-width: 396px;
+  padding: 28px 30px 24px;
+  border: 1px solid rgba(255, 255, 255, 0.085);
+  border-radius: 12px;
+  background: rgba(17, 17, 18, 0.86);
+  box-shadow:
+    0 1px 0 rgba(255, 255, 255, 0.035) inset,
+    0 20px 48px rgba(0, 0, 0, 0.52),
+    0 2px 8px rgba(0, 0, 0, 0.38);
+  backdrop-filter: blur(10px);
+  animation: entrance-card 720ms var(--ease-out-quint) 120ms both;
+}
+
+/* ---- Brand lockup ------------------------------------------------------- */
+
+.login-panel__brand {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding-bottom: 18px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.07);
+}
+
+.login-panel__word {
+  display: inline-flex;
+  gap: 0.34em;
+  color: #fff;
+  font-size: 14.5px;
+  font-weight: 570;
+  letter-spacing: 0.13em;
+}
+
+.login-panel__word-accent {
+  color: rgba(226, 233, 234, 0.58);
+  font-weight: 420;
+}
+
+/* ---- Heading ------------------------------------------------------------ */
+
+.login-panel__heading {
+  margin-top: 22px;
+  color: #fff;
+  font-family: var(--font-display);
+  font-size: 25px;
+  font-weight: 500;
+  letter-spacing: -0.018em;
+  line-height: 1.16;
+}
+
+.login-panel__sub {
+  margin-top: 7px;
+  color: rgba(226, 229, 228, 0.66);
+  font-size: 13px;
+  font-weight: 350;
+  line-height: 1.45;
+}
+
+/* ---- Form --------------------------------------------------------------- */
+
+.login-form {
+  display: flex;
+  flex-direction: column;
+  margin-top: 24px;
+}
+
+.login-field {
+  display: block;
+}
+
+.login-field + .login-field {
+  margin-top: 15px;
+}
+
+.login-field__label {
+  display: block;
+  margin-bottom: 7px;
+  color: rgba(230, 233, 232, 0.72);
+  font-size: 12px;
+  font-weight: 480;
+  letter-spacing: 0.005em;
+}
+
+.login-field__input {
+  width: 100%;
+  height: 43px;
+  padding: 0 13px;
+  border: 1px solid rgba(255, 255, 255, 0.11);
+  border-radius: 8px;
+  background: rgba(0, 0, 0, 0.32);
+  color: var(--text-primary);
+  font-size: 14px;
+  letter-spacing: 0.02em;
+  transition:
+    border-color 150ms ease,
+    background-color 150ms ease,
+    box-shadow 150ms ease;
+}
+
+.login-field__input::placeholder {
+  color: rgba(232, 236, 238, 0.28);
+  letter-spacing: 0.06em;
+}
+
+/* Neutral focus treatment — a brighter hairline, not a coloured ring. */
+.login-field__input:focus {
+  outline: none;
+  border-color: rgba(255, 255, 255, 0.3);
+  background: rgba(0, 0, 0, 0.42);
+  box-shadow: 0 0 0 3px rgba(255, 255, 255, 0.045);
+}
+
+.login-field__input:disabled {
+  opacity: 0.6;
+}
+
+.login-form__error {
+  min-height: 17px;
+  margin: 10px 0 4px;
+  color: #e2686b;
+  font-size: 11.5px;
+  font-weight: 450;
+  line-height: 1.35;
+}
+
+/* ---- Submit: the landing page's white CTA, full width -------------------- */
+
+.login-submit {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 46px;
+  border-radius: 7px;
+  background: #fff;
+  color: #111;
+  box-shadow: 0 1px 5px rgba(0, 0, 0, 0.38);
+  transition: filter 140ms ease;
+}
+
+.login-submit__label {
+  font-size: 12.5px;
+  font-weight: 560;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+}
+
+.login-submit__arrow {
+  position: absolute;
+  right: 5px;
+  top: 6px;
+  bottom: 6px;
+  display: grid;
+  place-items: center;
+  width: 36px;
+  border-radius: 7px;
+  background: #070909;
+  color: #fff;
+}
+
+.login-submit:hover:not(:disabled) {
+  filter: brightness(0.95);
+}
+
+.login-submit:disabled {
+  cursor: progress;
+  opacity: 0.84;
+}
+
+.login-submit__spinner {
+  width: 13px;
+  height: 13px;
+  border: 1.8px solid rgba(255, 255, 255, 0.26);
+  border-top-color: #fff;
+  border-radius: 50%;
+  animation: login-spin 620ms linear infinite;
+}
+
+@keyframes login-spin {
+  to {
+    transform: rotate(1turn);
+  }
+}
+
+/* ---- Footer ------------------------------------------------------------- */
+
+.login-panel__foot {
+  margin-top: 22px;
+  padding-top: 16px;
+  border-top: 1px solid rgba(255, 255, 255, 0.07);
+}
+
+.login-back {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  color: rgba(226, 229, 228, 0.62);
+  font-size: 12px;
+  font-weight: 450;
+  letter-spacing: 0.02em;
+  transition: color 150ms ease;
+}
+
+.login-back:hover {
+  color: #fff;
+}
+
+/* Reuse the arrow glyph pointing back. */
+.login-back__icon {
+  transform: rotate(180deg);
+}
+
+/* ---- Responsive --------------------------------------------------------- */
+
+@media (max-width: 479px) {
+  .login-layout {
+    padding: 18px;
+    place-items: center stretch;
+  }
+
+  .login-panel {
+    max-width: none;
+    padding: 24px 22px 20px;
+  }
+
+  .login-panel__heading {
+    font-size: 22px;
+  }
+}

--- a/frontend/src/routes/LoginPage.jsx
+++ b/frontend/src/routes/LoginPage.jsx
@@ -1,0 +1,128 @@
+import { useState } from 'react'
+import { Link, useNavigate } from 'react-router-dom'
+
+import BrandMark from '../components/BrandMark.jsx'
+import CinematicBackground from '../components/landing/CinematicBackground.jsx'
+import Icon from '../components/ui/Icon.jsx'
+import useRouteMode from '../hooks/useRouteMode.js'
+import { authenticate } from '../services/authService.js'
+import '../styles/cinematic.css'
+import './LoginPage.css'
+
+/**
+ * Investigator sign-in.
+ *
+ * Same footage, branding and typography as the landing route, turned down: the
+ * background is darkened and slowed, and the panel is a plain charcoal surface
+ * rather than the landing's expressive glass. No credential check happens here —
+ * see authService.
+ */
+export default function LoginPage() {
+  useRouteMode('cinematic')
+  const navigate = useNavigate()
+
+  const [investigatorId, setInvestigatorId] = useState('')
+  const [password, setPassword] = useState('')
+  const [pending, setPending] = useState(false)
+  const [error, setError] = useState(null)
+
+  async function handleSubmit(event) {
+    event.preventDefault()
+    if (pending) return
+
+    if (!investigatorId.trim() || !password) {
+      setError('Enter an investigator ID and password to continue.')
+      return
+    }
+
+    setError(null)
+    setPending(true)
+    await authenticate({ investigatorId })
+    navigate('/dashboard', { replace: true })
+  }
+
+  return (
+    <main className="viewport">
+      <section className="screen login">
+        <CinematicBackground dim />
+
+        <div className="login-layout">
+          <section className="login-panel" aria-labelledby="login-heading">
+            <div className="login-panel__brand">
+              <BrandMark size={24} />
+              <span className="login-panel__word">
+                CYBER<span className="login-panel__word-accent">TRIAGE</span>
+              </span>
+            </div>
+
+            <h1 className="login-panel__heading" id="login-heading">
+              Investigator Sign In
+            </h1>
+            <p className="login-panel__sub">Sign in to access Cyber Triage.</p>
+
+            <form className="login-form" onSubmit={handleSubmit} noValidate>
+              <label className="login-field">
+                <span className="login-field__label">Investigator ID</span>
+                <input
+                  className="login-field__input mono"
+                  type="text"
+                  name="investigatorId"
+                  autoComplete="username"
+                  placeholder="INV-0000"
+                  value={investigatorId}
+                  onChange={(event) => setInvestigatorId(event.target.value)}
+                  disabled={pending}
+                  autoFocus
+                />
+              </label>
+
+              <label className="login-field">
+                <span className="login-field__label">Password</span>
+                <input
+                  className="login-field__input"
+                  type="password"
+                  name="password"
+                  autoComplete="current-password"
+                  placeholder="••••••••••••"
+                  value={password}
+                  onChange={(event) => setPassword(event.target.value)}
+                  disabled={pending}
+                />
+              </label>
+
+              {/* Fixed-height row so the panel does not shift when validation fires. */}
+              <p className="login-form__error" role="alert">
+                {error ?? ''}
+              </p>
+
+              <button className="login-submit" type="submit" disabled={pending}>
+                <span className="login-submit__label">
+                  {pending ? 'Authenticating' : 'Authenticate'}
+                </span>
+                <span className="login-submit__arrow" aria-hidden="true">
+                  {pending ? (
+                    <span className="login-submit__spinner" />
+                  ) : (
+                    <Icon name="arrowRight" size={14} strokeWidth={1.7} />
+                  )}
+                </span>
+              </button>
+            </form>
+
+            <footer className="login-panel__foot">
+              <Link className="login-back" to="/">
+                <Icon
+                  name="arrowRight"
+                  size={13}
+                  strokeWidth={1.7}
+                  className="login-back__icon"
+                />
+                Back to landing
+              </Link>
+            </footer>
+          </section>
+        </div>
+      </section>
+    </main>
+  )
+}

--- a/frontend/src/routes/ModulePlaceholder.css
+++ b/frontend/src/routes/ModulePlaceholder.css
@@ -1,0 +1,62 @@
+.module-card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+  padding: 52px 28px 56px;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-lg);
+  background: var(--bg-panel);
+  text-align: center;
+}
+
+.module-card__icon {
+  display: grid;
+  place-items: center;
+  width: 46px;
+  height: 46px;
+  margin-bottom: 4px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 50%;
+  background: var(--bg-inset);
+  color: var(--text-muted);
+}
+
+.module-card__title {
+  color: var(--text-primary);
+  font-size: 15px;
+  font-weight: 530;
+  letter-spacing: -0.01em;
+}
+
+.module-card__copy {
+  max-width: 46ch;
+  color: var(--text-muted);
+  font-size: 12.5px;
+  font-weight: 430;
+  line-height: 1.55;
+}
+
+.module-card__back {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  margin-top: 10px;
+  padding: 7px 13px;
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-sm);
+  background: var(--bg-panel-raised);
+  color: var(--text-secondary);
+  font-size: 11.5px;
+  font-weight: 490;
+  transition:
+    border-color 130ms ease,
+    color 130ms ease,
+    background-color 130ms ease;
+}
+
+.module-card__back:hover {
+  border-color: var(--border-strong);
+  background: var(--bg-panel-hover);
+  color: var(--text-primary);
+}

--- a/frontend/src/routes/ModulePlaceholder.jsx
+++ b/frontend/src/routes/ModulePlaceholder.jsx
@@ -1,0 +1,43 @@
+import { Link } from 'react-router-dom'
+import Icon from '../components/ui/Icon.jsx'
+import '../styles/page.css'
+import './ModulePlaceholder.css'
+
+/**
+ * Stand-in for the forensic modules that arrive after Phase 1.
+ *
+ * The route exists so the sidebar is honest — every destination resolves — but
+ * the screen states plainly that the module is not implemented rather than
+ * showing an empty table that looks broken.
+ *
+ * @param {{ title: string, phase?: string }} props
+ */
+export default function ModulePlaceholder({ title, phase }) {
+  return (
+    <div className="page module-placeholder">
+      <header className="page-head">
+        <div className="page-head__titles">
+          <h1 className="page-head__title">{title}</h1>
+          <p className="page-head__subtitle">Not implemented in this build</p>
+        </div>
+      </header>
+
+      <section className="module-card">
+        <span className="module-card__icon">
+          <Icon name="lock" size={20} />
+        </span>
+
+        <h2 className="module-card__title">{title} is not available yet</h2>
+        <p className="module-card__copy">
+          {phase ??
+            'This module is scheduled for a later phase of the build.'}
+        </p>
+
+        <Link className="module-card__back" to="/dashboard">
+          <Icon name="dashboard" size={13} />
+          Back to dashboard
+        </Link>
+      </section>
+    </div>
+  )
+}

--- a/frontend/src/services/apiClient.js
+++ b/frontend/src/services/apiClient.js
@@ -1,0 +1,90 @@
+/**
+ * Minimal fetch wrapper for the Cyber Triage backend.
+ *
+ * Base URL resolution:
+ *   - `VITE_API_BASE_URL` if set (e.g. a deployed backend origin)
+ *   - otherwise `/api`, which the Vite dev server proxies to Flask on :5000
+ *     (see vite.config.js)
+ *
+ * Nothing in Phase 1 calls a mutating endpoint. This exists so that when the
+ * real endpoints are wired up, components keep talking to services and never
+ * to `fetch` directly.
+ */
+
+const BASE_URL = import.meta.env.VITE_API_BASE_URL ?? '/api'
+
+export class ApiError extends Error {
+  constructor(message, { status, code, payload } = {}) {
+    super(message)
+    this.name = 'ApiError'
+    this.status = status
+    this.code = code
+    this.payload = payload
+  }
+}
+
+async function parseBody(response) {
+  const contentType = response.headers.get('content-type') ?? ''
+  if (contentType.includes('application/json')) {
+    return response.json()
+  }
+  return response.text()
+}
+
+/**
+ * @param {string} path  Endpoint path relative to the API base, e.g. `/health`.
+ * @param {RequestInit & { signal?: AbortSignal }} [options]
+ */
+export async function request(path, options = {}) {
+  let response
+  try {
+    response = await fetch(`${BASE_URL}${path}`, options)
+  } catch (cause) {
+    // Network-level failure: backend not running, DNS, offline, aborted.
+    throw new ApiError('Unable to reach the Cyber Triage backend.', {
+      code: 'NETWORK_ERROR',
+      payload: cause,
+    })
+  }
+
+  const body = await parseBody(response)
+
+  if (!response.ok) {
+    // backend/app.py returns either {error: {code, message}} or {error: "..."}.
+    const error = typeof body === 'object' && body !== null ? body.error : null
+    const message =
+      (typeof error === 'object' && error?.message) ||
+      (typeof error === 'string' && error) ||
+      `Request failed with status ${response.status}`
+
+    throw new ApiError(message, {
+      status: response.status,
+      code: (typeof error === 'object' && error?.code) || 'HTTP_ERROR',
+      payload: body,
+    })
+  }
+
+  return body
+}
+
+export function get(path, options) {
+  return request(path, { method: 'GET', ...options })
+}
+
+export function postJson(path, data, options) {
+  return request(path, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data),
+    ...options,
+  })
+}
+
+/** Multipart upload. The backend reads the part named `file`. */
+export function postFile(path, file, options) {
+  const form = new FormData()
+  form.append('file', file)
+  return request(path, { method: 'POST', body: form, ...options })
+}
+
+export { BASE_URL }

--- a/frontend/src/services/authService.js
+++ b/frontend/src/services/authService.js
@@ -1,0 +1,57 @@
+/**
+ * Prototype session handling.
+ *
+ * There is no authentication in Phase 1 and none on the Flask backend either.
+ * This stores the submitted investigator ID so the top bar can show a session
+ * indicator, and nothing more. It is NOT a security boundary — swap this whole
+ * module for a real token exchange when auth lands.
+ */
+
+const SESSION_KEY = 'cyber-triage:session'
+
+/** @returns {{ investigatorId: string, signedInAt: string } | null} */
+export function getSession() {
+  try {
+    const raw = sessionStorage.getItem(SESSION_KEY)
+    return raw ? JSON.parse(raw) : null
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Records a prototype session. Resolves after a short delay so the login
+ * button's pending state is visible — the real call will be async too.
+ */
+export function authenticate({ investigatorId }) {
+  const session = {
+    investigatorId: investigatorId.trim(),
+    signedInAt: new Date().toISOString(),
+  }
+
+  return new Promise((resolve) => {
+    setTimeout(() => {
+      try {
+        sessionStorage.setItem(SESSION_KEY, JSON.stringify(session))
+      } catch {
+        // Private-mode storage failure is not fatal for a prototype.
+      }
+      resolve(session)
+    }, 450)
+  })
+}
+
+export function signOut() {
+  try {
+    sessionStorage.removeItem(SESSION_KEY)
+  } catch {
+    // no-op
+  }
+}
+
+/** Falls back to a placeholder so the shell renders if /dashboard is hit directly. */
+export function getInvestigatorLabel() {
+  const session = getSession()
+  if (!session?.investigatorId) return 'INV-0000'
+  return session.investigatorId.toUpperCase()
+}

--- a/frontend/src/services/dashboardService.js
+++ b/frontend/src/services/dashboardService.js
@@ -1,0 +1,40 @@
+/**
+ * Dashboard data source.
+ *
+ * Phase 1 resolves the static mock fixtures. When the backend grows case
+ * persistence and artifact retrieval, replace each function body with the
+ * corresponding call from `triageService` — the component contracts do not
+ * change, because they already consume these promises.
+ */
+
+import {
+  ACTIVE_INVESTIGATIONS,
+  AI_TRIAGE,
+  DASHBOARD_METRICS,
+  RECENT_ACTIVITY,
+  TRIAGE_BY_CASE,
+} from '../data/mockDashboard.js'
+
+export function fetchDashboardMetrics() {
+  return Promise.resolve(DASHBOARD_METRICS)
+}
+
+export function fetchActiveInvestigations() {
+  return Promise.resolve(ACTIVE_INVESTIGATIONS)
+}
+
+/**
+ * Mock triage summary. These findings are authored UI fixtures — no model
+ * produced them. The real version will be derived from /api/analyze output
+ * plus the rule hits already emitted by ml/risk_scorer.py.
+ *
+ * Resolves `null` for cases the pipeline has not scored yet.
+ */
+export function fetchTriageSummary(caseId) {
+  if (!caseId) return Promise.resolve(AI_TRIAGE)
+  return Promise.resolve(TRIAGE_BY_CASE[caseId] ?? null)
+}
+
+export function fetchRecentActivity() {
+  return Promise.resolve(RECENT_ACTIVITY)
+}

--- a/frontend/src/services/triageService.js
+++ b/frontend/src/services/triageService.js
@@ -1,0 +1,64 @@
+/**
+ * Backend endpoints exposed by backend/app.py.
+ *
+ * Phase 1 does not call these from the UI yet — the dashboard renders mock data.
+ * They are defined now so the wiring is a matter of swapping the data source in
+ * `dashboardService`, not of rewriting components.
+ */
+
+import { get, postFile } from './apiClient.js'
+
+/** GET /api/health -> { status, service } */
+export function checkHealth(options) {
+  return get('/health', options)
+}
+
+/**
+ * POST /api/analyze (multipart, field `file`)
+ *
+ * Returns `{ summary: { total_records, critical, high, medium, low },
+ *            artifacts: [...], evaluation?: { label_column, metrics } }`
+ * where each artifact carries record_id, artifact_type, anomaly_score,
+ * rule_score, risk_score, priority and matched_rules.
+ */
+export function analyzeDataset(file, options) {
+  return postFile('/analyze', file, options)
+}
+
+/**
+ * POST /api/evaluate (multipart, field `file`)
+ *
+ * Requires a labelled dataset. Returns classification metrics plus the
+ * top-k triage metrics used on the Analysis screen in a later phase.
+ */
+export function evaluateModel(file, options) {
+  return postFile('/evaluate', file, options)
+}
+
+/**
+ * POST /api/report
+ *
+ * Currently a 501 stub on the backend (report generation is a later phase).
+ */
+export function generateReport(payload, options) {
+  return postFile('/report', payload, options)
+}
+
+/**
+ * Normalises an /api/analyze artifact into the shape the UI components use,
+ * so the mock data and the real payload stay interchangeable.
+ */
+export function toArtifactViewModel(artifact) {
+  return {
+    id: String(artifact.record_id),
+    type: artifact.artifact_type,
+    anomalyScore: artifact.anomaly_score,
+    ruleScore: artifact.rule_score,
+    riskScore: artifact.risk_score,
+    severity: artifact.priority,
+    matchedRules:
+      artifact.matched_rules && artifact.matched_rules !== 'None'
+        ? artifact.matched_rules.split(',').map((rule) => rule.trim())
+        : [],
+  }
+}

--- a/frontend/src/styles/cinematic.css
+++ b/frontend/src/styles/cinematic.css
@@ -1,0 +1,148 @@
+/**
+ * Shared foundation for the cinematic routes (landing + login).
+ *
+ * Layout tokens follow frontend/landingpage.md. Two deliberate deviations:
+ *
+ *  1. `--display-size` / `--display-leading` carry a `min(..., vw)` guard. The
+ *     reference sizes the headline off viewport *height* only, which is safe for
+ *     its short copy ("Stop Digging"). Our longest line — "Clear Answers.
+ *     Faster." — is wider and overflows on tall-narrow viewports (e.g. portrait
+ *     tablets) without a width term.
+ *
+ *  2. Headline letter-spacing is `-0.024em` rather than a fixed `-2.1px`, so the
+ *     tracking stays proportional as the size clamps down. At the reference's
+ *     88px this resolves to ~-2.1px.
+ */
+
+.viewport {
+  position: fixed;
+  inset: 0;
+  isolation: isolate;
+  background: #000;
+}
+
+.screen {
+  --gutter-start: clamp(28px, 4.177vw, 96px);
+  --gutter-end: clamp(28px, 4.04vw, 96px);
+  --header-top: clamp(20px, 2.264vh, 30px);
+  --hero-bottom: clamp(34px, 5.19vh, 64px);
+
+  --display-size: clamp(40px, min(7.64vh, 8vw), 88px);
+  --display-leading: clamp(48px, min(9.34vh, 9.6vw), 106px);
+  --copy-size: clamp(14px, 1.7vh, 19px);
+  --copy-leading: clamp(19px, 2.17vh, 24px);
+
+  --title-copy-gap: clamp(15px, 2.08vh, 24px);
+  --copy-cta-gap: clamp(24px, 3.11vh, 36px);
+  --cta-width: clamp(148px, 15.09vh, 172px);
+  --cta-height: clamp(38px, 3.96vh, 44px);
+
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+  background: #000;
+}
+
+/* ---- Glass language ----------------------------------------------------- */
+
+.glass {
+  border: 1px solid var(--glass-border);
+  background: var(--glass-fill);
+  box-shadow: var(--glass-shadow);
+  backdrop-filter: var(--glass-blur);
+}
+
+.glass-cool {
+  border: 1px solid var(--glass-border-strong);
+  background: var(--glass-fill-cool);
+  backdrop-filter: blur(16px) saturate(110%);
+}
+
+/* ---- Interaction -------------------------------------------------------- */
+
+@media (prefers-reduced-motion: no-preference) {
+  .screen button,
+  .screen a {
+    transition:
+      filter 140ms ease,
+      opacity 140ms ease;
+  }
+
+  .screen button:hover,
+  .screen a:hover {
+    filter: brightness(1.08);
+  }
+}
+
+/* ---- Entrance choreography --------------------------------------------- */
+/* Delays and easings follow the reference timeline table. Pre-animation offsets
+   are applied via [data-motion='pending'] in the route stylesheets. */
+
+@keyframes entrance-brand {
+  from {
+    opacity: 0;
+    transform: translate3d(0, 7px, 0) scale(0.94);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+
+@keyframes entrance-nav {
+  from {
+    opacity: 0;
+    transform: translate3d(0, 6px, 0);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+
+@keyframes entrance-action {
+  from {
+    opacity: 0;
+    transform: translate3d(0, 8px, 0) scale(0.985);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+
+@keyframes entrance-line {
+  from {
+    transform: translate3d(0, 110%, 0) skewY(2deg);
+  }
+  to {
+    transform: none;
+  }
+}
+
+@keyframes entrance-copy {
+  from {
+    opacity: 0;
+    transform: translate3d(0, 10px, 0);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+
+/* Used by the login panel. */
+@keyframes entrance-card {
+  from {
+    opacity: 0;
+    transform: translate3d(0, 12px, 0) scale(0.968);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -1,0 +1,156 @@
+/* ---- Reset ------------------------------------------------------------- */
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+html,
+body,
+#root {
+  height: 100%;
+}
+
+body {
+  margin: 0;
+  background: var(--bg-base);
+  color: var(--text-primary);
+  font-family: var(--font-sans);
+  font-size: 14px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  text-rendering: optimizeLegibility;
+}
+
+/* The cinematic routes (landing, login) are a fixed full-viewport composition
+   with no page scroll. The application shell scrolls normally, so this is
+   toggled per route rather than set globally. */
+html[data-route-mode='cinematic'],
+html[data-route-mode='cinematic'] body {
+  overflow: hidden;
+  background: #000;
+}
+
+h1,
+h2,
+h3,
+h4,
+p {
+  margin: 0;
+}
+
+button {
+  margin: 0;
+  padding: 0;
+  border: none;
+  background: none;
+  color: inherit;
+  font: inherit;
+  letter-spacing: inherit;
+  cursor: pointer;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+input,
+select,
+textarea {
+  font: inherit;
+  color: inherit;
+}
+
+ul,
+ol {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+svg {
+  display: block;
+  flex: none;
+}
+
+/* ---- Focus ------------------------------------------------------------- */
+
+:focus-visible {
+  outline: 2px solid #fff;
+  outline-offset: 3px;
+  border-radius: 2px;
+}
+
+/* ---- Scrollbars -------------------------------------------------------- */
+
+* {
+  scrollbar-width: thin;
+  scrollbar-color: rgba(255, 255, 255, 0.16) transparent;
+}
+
+*::-webkit-scrollbar {
+  width: 10px;
+  height: 10px;
+}
+
+*::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+*::-webkit-scrollbar-thumb {
+  border: 3px solid transparent;
+  border-radius: var(--radius-pill);
+  background-clip: content-box;
+  background-color: rgba(255, 255, 255, 0.16);
+}
+
+*::-webkit-scrollbar-thumb:hover {
+  background-color: rgba(255, 255, 255, 0.26);
+}
+
+/* ---- Shared utilities -------------------------------------------------- */
+
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  overflow: hidden;
+  clip-path: inset(50%);
+  white-space: nowrap;
+  border: 0;
+}
+
+/* Quiet section label used throughout the application shell. Sentence case on
+   purpose — a screen full of tiny uppercase labels reads as decoration. */
+.eyebrow {
+  font-size: 11px;
+  font-weight: 520;
+  letter-spacing: 0.005em;
+  color: var(--text-muted);
+}
+
+.tabular {
+  font-variant-numeric: tabular-nums;
+}
+
+.mono {
+  font-family: var(--font-mono);
+  font-variant-numeric: tabular-nums;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-delay: 0ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}

--- a/frontend/src/styles/page.css
+++ b/frontend/src/styles/page.css
@@ -1,0 +1,69 @@
+/**
+ * Shared chrome for application pages rendered inside AppShell.
+ *
+ * Imported by the route components that use it (not globally) so the landing
+ * and login routes stay free of application styles.
+ */
+
+.page {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  max-width: 1720px;
+  padding: 20px var(--app-gutter) 40px;
+}
+
+.page-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.page-head__title {
+  color: var(--text-primary);
+  font-family: var(--font-display);
+  font-size: 21px;
+  font-weight: 520;
+  letter-spacing: -0.017em;
+  line-height: 1.15;
+}
+
+.page-head__subtitle {
+  margin-top: 5px;
+  color: var(--text-muted);
+  font-size: 12px;
+  font-weight: 440;
+}
+
+.page-head__sync {
+  font-variant-numeric: tabular-nums;
+}
+
+/* Standing reminder that nothing on screen came from a real pipeline run. It is
+   a provenance note, not a severity, so it carries no severity colour. */
+.page-head__notice {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 5px 10px;
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-pill);
+  background: var(--surface-tint);
+  color: var(--text-secondary);
+  font-size: 11px;
+  font-weight: 470;
+  letter-spacing: 0.005em;
+}
+
+@media (max-width: 767px) {
+  .page {
+    padding-top: 16px;
+    gap: 14px;
+  }
+
+  .page-head__title {
+    font-size: 18px;
+  }
+}

--- a/frontend/src/styles/tokens.css
+++ b/frontend/src/styles/tokens.css
@@ -1,0 +1,104 @@
+/**
+ * Cyber Triage design tokens.
+ *
+ * Two visual registers share one palette:
+ *   - the cinematic landing/login composition (near-black, glass, white CTA)
+ *   - the investigator application shell (layered charcoal panels, no accent hue)
+ *
+ * Colour policy for the application shell: hue carries severity and nothing
+ * else. Interaction states, active markers, focus rings and progress meters are
+ * neutral, so a red or orange element on screen always means "this finding is
+ * more serious", never "this thing is clickable".
+ *
+ * Severity colours are deliberately desaturated. A forensic tool has to read as
+ * an instrument, not an alarm panel, so CRITICAL is a deep brick red rather than
+ * a saturated #ff0000. LOW and INFO carry no hue at all — nothing to decide.
+ */
+
+:root {
+  /* ---- Typography -------------------------------------------------------- */
+  /* The reference names two proprietary variable faces. They are listed first
+     so a licensed install is picked up automatically; otherwise we fall back to
+     the platform's variable UI face (Segoe UI Variable on Windows, SF on mac). */
+  --font-sans: 'Reference Sans', 'Segoe UI Variable Text', 'Segoe UI', -apple-system,
+    BlinkMacSystemFont, 'Helvetica Neue', Arial, sans-serif;
+  --font-display: 'Reference Display', 'Segoe UI Variable Display', 'Segoe UI',
+    -apple-system, BlinkMacSystemFont, 'Helvetica Neue', Arial, sans-serif;
+  --font-mono: 'Cascadia Mono', 'SF Mono', 'Consolas', 'Roboto Mono', ui-monospace, monospace;
+
+  /* ---- Application surfaces --------------------------------------------- */
+  --bg-base: #07090b;
+  --bg-sunken: #050708;
+  --bg-panel: #0d1114;
+  --bg-panel-raised: #11161a;
+  --bg-panel-hover: #151b20;
+  --bg-inset: #0a0e11;
+
+  --border-subtle: rgba(255, 255, 255, 0.07);
+  --border-default: rgba(255, 255, 255, 0.11);
+  --border-strong: rgba(255, 255, 255, 0.18);
+
+  --text-primary: #e7ecee;
+  --text-secondary: rgba(231, 236, 238, 0.66);
+  --text-muted: rgba(231, 236, 238, 0.42);
+  --text-faint: rgba(231, 236, 238, 0.26);
+  --text-inverse: #0a0c0d;
+
+  /* ---- Neutral interaction (no hue: colour is reserved for severity) ----- */
+  --marker: rgba(231, 236, 238, 0.7);
+  --marker-dim: rgba(231, 236, 238, 0.34);
+  --focus-ring: rgba(255, 255, 255, 0.12);
+  --surface-tint: rgba(255, 255, 255, 0.045);
+
+  /* ---- Severity scale ---------------------------------------------------- */
+  /* CRITICAL red · HIGH orange · MEDIUM amber · LOW and INFO neutral. */
+  --sev-critical: #d9484c;
+  --sev-critical-bg: rgba(217, 72, 76, 0.13);
+  --sev-critical-border: rgba(217, 72, 76, 0.36);
+
+  --sev-high: #d9843c;
+  --sev-high-bg: rgba(217, 132, 60, 0.13);
+  --sev-high-border: rgba(217, 132, 60, 0.34);
+
+  --sev-medium: #cdae42;
+  --sev-medium-bg: rgba(205, 174, 66, 0.12);
+  --sev-medium-border: rgba(205, 174, 66, 0.32);
+
+  --sev-low: rgba(231, 236, 238, 0.6);
+  --sev-low-bg: rgba(255, 255, 255, 0.045);
+  --sev-low-border: rgba(255, 255, 255, 0.13);
+
+  --sev-info: rgba(231, 236, 238, 0.46);
+  --sev-info-bg: rgba(255, 255, 255, 0.035);
+  --sev-info-border: rgba(255, 255, 255, 0.1);
+
+  /* ---- Glass language (shared with the landing composition) ------------- */
+  --glass-border: rgba(255, 255, 255, 0.13);
+  --glass-border-strong: rgba(255, 255, 255, 0.21);
+  --glass-fill: linear-gradient(145deg, rgba(24, 22, 20, 0.8), rgba(5, 12, 14, 0.86));
+  --glass-fill-cool: linear-gradient(145deg, rgba(26, 34, 36, 0.86), rgba(16, 29, 33, 0.9));
+  --glass-shadow: 0 2px 10px rgba(0, 0, 0, 0.44), 0 0 0 3px rgba(255, 255, 255, 0.035) inset,
+    0 0 0 1px rgba(0, 0, 0, 0.9);
+  --glass-blur: blur(14px) saturate(108%);
+
+  /* ---- Radii / elevation ------------------------------------------------- */
+  --radius-sm: 5px;
+  --radius-md: 8px;
+  --radius-lg: 12px;
+  --radius-pill: 999px;
+
+  --shadow-raised: 0 8px 28px rgba(0, 0, 0, 0.5);
+
+  /* ---- Application layout ------------------------------------------------ */
+  --sidebar-width: 232px;
+  --sidebar-width-collapsed: 64px;
+  --topbar-height: 56px;
+  --app-gutter: 24px;
+
+  /* ---- Motion ------------------------------------------------------------ */
+  --ease-out-expo: cubic-bezier(0.16, 1, 0.3, 1);
+  --ease-out-quint: cubic-bezier(0.22, 1, 0.36, 1);
+
+  color-scheme: dark;
+  font-family: var(--font-sans);
+}

--- a/frontend/src/utils/format.js
+++ b/frontend/src/utils/format.js
@@ -1,0 +1,51 @@
+/** Number and label formatting helpers shared across the dashboard. */
+
+const compactFormatter = new Intl.NumberFormat('en-US', {
+  notation: 'compact',
+  maximumFractionDigits: 2,
+})
+
+const plainFormatter = new Intl.NumberFormat('en-US')
+
+/**
+ * @param {number} value
+ * @param {'compact'|'plain'} [format]
+ */
+export function formatCount(value, format = 'plain') {
+  if (typeof value !== 'number' || Number.isNaN(value)) return '—'
+  return format === 'compact' ? compactFormatter.format(value) : plainFormatter.format(value)
+}
+
+/** 0.92 -> "92%" */
+export function formatPercent(ratio, digits = 0) {
+  if (typeof ratio !== 'number' || Number.isNaN(ratio)) return '—'
+  return `${(ratio * 100).toFixed(digits)}%`
+}
+
+/** ISO timestamp -> "24 Aug 2026, 02:14:37" */
+export function formatTimestamp(iso) {
+  if (!iso) return '—'
+  const date = new Date(iso)
+  if (Number.isNaN(date.getTime())) return '—'
+  return new Intl.DateTimeFormat('en-GB', {
+    day: '2-digit',
+    month: 'short',
+    year: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    hour12: false,
+  }).format(date)
+}
+
+/** ISO timestamp -> "24 Aug 2026" */
+export function formatDate(iso) {
+  if (!iso) return '—'
+  const date = new Date(iso)
+  if (Number.isNaN(date.getTime())) return '—'
+  return new Intl.DateTimeFormat('en-GB', {
+    day: '2-digit',
+    month: 'short',
+    year: 'numeric',
+  }).format(date)
+}

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,0 +1,17 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173,
+    // Lets the frontend call the existing Flask API at /api/* without CORS juggling
+    // once the two are wired together. Flask runs on :5000 (backend/app.py).
+    proxy: {
+      '/api': {
+        target: 'http://localhost:5000',
+        changeOrigin: true,
+      },
+    },
+  },
+})


### PR DESCRIPTION
## Summary

Builds the investigator frontend the repo previously only had a `.gitkeep` for. Three routes wired end to end: **Landing → Get Started → Login → Authenticate → Dashboard**.

Vite + React 19 + react-router-dom, plain CSS custom properties. Three runtime dependencies — icons, severity meters and score readouts are hand-rolled rather than pulling in a chart or icon library.

**No backend or ML code was changed.**

## What's here

- **Landing** — cinematic background, single `GET STARTED` CTA, no fake metrics or dashboard preview.
- **Login** — investigator sign-in. UI prototype; there is no real authentication.
- **Dashboard** — investigation overview, active case list, triage summary panel, recent activity.
- **Module placeholders** for the sidebar destinations that later phases will fill (Evidence, IOC Graph, Reports, …), each naming what will replace it.
- **Service layer** — components never call `fetch` directly. They go through `authService` / `dashboardService` / `triageService` to a shared `apiClient`, so the existing Flask endpoints can be attached without touching component code. Vite proxies `/api` → `localhost:5000`.

## Design decisions worth keeping

- **Colour is reserved for severity.** There are no accent tokens in `tokens.css` to reach for, so interaction states, focus rings and progress meters are neutral greys. A red or orange element always means "more serious", never "clickable".
- **Severity thresholds mirror `ml/risk_scorer.py`** — CRITICAL ≥ 75, HIGH ≥ 50, MEDIUM ≥ 25. Change one, change both.
- **Sample data stays labelled as sample data.** Everything on the dashboard is authored fixtures in `data/mockDashboard.js`; the UI says so in three places. No model output is implied.

## Also in this PR

- **README corrections** — it listed Tailwind and Recharts (neither is used) and an `npm start` script that doesn't exist. Now documents the real stack, the four API endpoints with honest status (`/api/report` is a 501 stub), and the scoring model.
- **`CLAUDE_CONTEXT.md`** — a handoff document so a new contributor or agent session doesn't have to re-derive the architecture.
- **`.gitignore`** — adds `frontend/dist/` (Vite's output dir; only CRA's `build/` was covered), plus `.claude/` and the local third-party design reference.

## Verification

`npm run build` passes — 67 modules, 39.90 kB CSS, 270.96 kB JS.

The full flow was walked in a browser with assertions on the DOM and computed styles: correct headings and CTA count on landing, the login form rendering and submitting, and the dashboard rendering 4 cases and 5 metrics with severity rails resolving to the right per-case colours.

**There are no automated tests in this repo**, so the build is the only mechanical check.

## Known limitations

- The dashboard is not yet connected to `/api/analyze` — the service layer exists for it, but nothing calls a live endpoint.
- `frontend/src/config/media.js` points the landing background video at a third-party CloudFront URL from the design reference. It needs self-hosting before deployment; `CinematicBackground` falls back to a CSS gradient if it fails to load.
- Login is cosmetic. Do not treat it as an access control boundary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
